### PR TITLE
[roster] 26510126

### DIFF
--- a/roster/26510126.md
+++ b/roster/26510126.md
@@ -1,0 +1,4 @@
+# 26510126
+
+- github: thisjonghoon
+- name: Jonghoon Lee


### PR DESCRIPTION
## What I built

Week-01 roster registration: adds `roster/26510126.md` mapping student id 26510126 to @thisjonghoon (Jonghoon Lee).

## What I tried and discarded

Nothing discarded on the content side — this is a single-file roster PR. Two setup snags worth recording:

- HTTPS push had no stored credential on this machine, and SSH over port 22 was blocked by the network. Switched `origin` to SSH over port 443 (`ssh.github.com:443`), which authenticated fine.
- Tried opening this PR through a GitHub App integration first; it returned `403 Resource not accessible by integration` because the app is not installed on the upstream repo. Installed the `gh` CLI and authenticated with a personal account instead.

## How to run

N/A for a roster PR. The ownership check was run locally before pushing:

```
python scripts/check_pr_paths.py thisjonghoon roster/26510126.md
# ownership check passed for @thisjonghoon (1 file(s))
```

## Note for the instructor

The `week-01` PR (#6) branches off this one and carries this same commit, so its
file list shows `roster/26510126.md` as well. Merging this one first leaves #6's
diff as the submission directory only. Happy to rebase if you would rather take
them in the other order.

## Checklist

- [x] `python scripts/check_week01.py submissions/<student-id>/week-01` passes locally (N/A — roster PR)
- [x] Run logs are committed under `logs/` (N/A — roster PR)
- [x] No API keys anywhere in the diff
- [x] History is not squashed

## Disclosure

Per the course LLM policy, this PR was prepared with Claude Code (Opus 5). The
single commit carries a `Co-Authored-By` trailer, and the setup snags above are
recorded as-is rather than tidied away.
