### PR TITLE
[roster] 25620027

### DIFF
--- a/roster/25620027.md
+++ b/roster/25620027.md
@@ -1,0 +1,4 @@
+# 25620027
+
+- github: SungJinho
+- name: 성진호


### PR DESCRIPTION
## What I built

Added the roster entry mapping student ID `25620027` to GitHub account `SungJinho`.

## What I tried and discarded

No discarded implementation was needed for this one-time roster setup.

## How to run

Not applicable for a roster-only PR.

## Checklist

- [x] Roster filename is the student ID
- [x] `github:` matches the PR author
- [x] The PR changes only `roster/25620027.md`
- [x] No API keys are included
- [x] History is not squashed