### PR TITLE
[week-01] 25622005

### DIFF
--- a/roster/25622005.md
+++ b/roster/25622005.md
@@ -1,0 +1,4 @@
+# 25622005
+
+- github: psyoung82
+- name: Soonyoung Park

--- a/submissions/25622005/week-01/TOOLS.md
+++ b/submissions/25622005/week-01/TOOLS.md
@@ -1,0 +1,16 @@
+# TOOLS.md
+
+The third tool is `clock`, which returns the current time as an ISO 8601 UTC
+timestamp plus a unix epoch in seconds, and takes no arguments. I wrote the
+description to tell the model *why* it would want to call this tool, not just
+*what* it does: "call it once before and once after a task to compute how
+many seconds the task took, by subtracting the two unix epoch values." A bare
+description like "return the current time" would let the model call `clock`
+correctly, but wouldn't tell it that calling it twice — at the start and end
+of the run — is the intended pattern for self-timing, which is the actual
+task in this assignment (sum notes.txt and report elapsed seconds). Returning
+both an ISO string and a unix epoch is deliberate too: the epoch is what
+`calculator` can subtract to get a duration, while the ISO string is what a
+human reads in the log to sanity-check the epoch is right. Since the
+description is the only interface the model sees, both the ordering
+instruction and the dual format had to live in that one string.

--- a/submissions/25622005/week-01/TOOLS.md
+++ b/submissions/25622005/week-01/TOOLS.md
@@ -1,16 +1,3 @@
 # TOOLS.md
 
-The third tool is `clock`, which returns the current time as an ISO 8601 UTC
-timestamp plus a unix epoch in seconds, and takes no arguments. I wrote the
-description to tell the model *why* it would want to call this tool, not just
-*what* it does: "call it once before and once after a task to compute how
-many seconds the task took, by subtracting the two unix epoch values." A bare
-description like "return the current time" would let the model call `clock`
-correctly, but wouldn't tell it that calling it twice — at the start and end
-of the run — is the intended pattern for self-timing, which is the actual
-task in this assignment (sum notes.txt and report elapsed seconds). Returning
-both an ISO string and a unix epoch is deliberate too: the epoch is what
-`calculator` can subtract to get a duration, while the ISO string is what a
-human reads in the log to sanity-check the epoch is right. Since the
-description is the only interface the model sees, both the ordering
-instruction and the dual format had to live in that one string.
+세 번째 도구는 `clock`이다. 인자를 받지 않고, 현재 시각을 ISO 8601 UTC 타임스탬프와 유닉스 에폭(초)으로 함께 돌려준다. 설명(description)을 쓸 때 모델에게 이 도구가 *무엇을 하는지*뿐 아니라 *왜* 불러야 하는지까지 알려주려 했다: "작업 시작 전과 후에 한 번씩 호출해서, 두 유닉스 에폭 값을 빼면 작업에 걸린 초를 계산할 수 있다"고 적었다. 만약 "현재 시각을 반환한다"처럼 밋밋하게만 썼다면 모델이 `clock`을 올바르게 호출하긴 하겠지만, 실행 시작과 끝에 두 번 불러 스스로 시간을 재는 것이 의도된 사용 패턴이라는 점은 전달되지 않았을 것이다. 그리고 그 자기-시간측정이 바로 이번 과제의 실제 태스크다(notes.txt의 숫자를 합산하고, 걸린 초를 함께 보고하는 것). ISO 문자열과 유닉스 에폭을 둘 다 반환하도록 한 것도 의도적인 선택이다. 에폭 값은 `calculator`가 뺄셈으로 소요 시간을 구할 수 있는 형식이고, ISO 문자열은 로그를 읽는 사람이 그 에폭 값이 맞는지 눈으로 바로 확인할 수 있는 형식이다. 모델이 보는 인터페이스는 이 설명 문자열 하나뿐이므로, 호출 순서에 대한 지침과 이중 포맷 모두 그 한 문장 안에 담아야 했다.

--- a/submissions/25622005/week-01/first_agent.py
+++ b/submissions/25622005/week-01/first_agent.py
@@ -1,0 +1,89 @@
+"""Week 01 starter — the agent from the lab, Anthropic API version.
+
+Two tools: calculator, read_file. Your assignment: add a third.
+Requires: pip install anthropic, and ANTHROPIC_API_KEY in the environment.
+"""
+import os
+import sys
+import ast
+import operator
+
+import anthropic
+
+# ---- tool 1: calculator (safe, no eval) ----
+_OPS = {ast.Add: operator.add, ast.Sub: operator.sub,
+        ast.Mult: operator.mul, ast.Div: operator.truediv,
+        ast.Pow: operator.pow, ast.USub: operator.neg}
+
+
+def _ev(node):
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.BinOp):
+        return _OPS[type(node.op)](_ev(node.left), _ev(node.right))
+    if isinstance(node, ast.UnaryOp):
+        return _OPS[type(node.op)](_ev(node.operand))
+    raise ValueError("expression not allowed")
+
+
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression string, e.g. '3 * (4 + 5)'."""
+    return str(_ev(ast.parse(expression, mode="eval").body))
+
+
+# ---- tool 2: read_file (blocked outside the working directory) ----
+def read_file(path: str) -> str:
+    """Return the contents of a text file."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    with open(full, encoding="utf-8") as f:
+        return f.read()[:4000]
+
+
+TOOLS_IMPL = {"calculator": calculator, "read_file": read_file}
+
+# ---- tool schemas handed to the model (the description IS the interface) ----
+TOOLS = [
+    {"name": "calculator",
+     "description": "Evaluate an arithmetic expression.",
+     "input_schema": {"type": "object",
+                      "properties": {"expression": {"type": "string"}},
+                      "required": ["expression"]}},
+    {"name": "read_file",
+     "description": "Read a text file in the working directory.",
+     "input_schema": {"type": "object",
+                      "properties": {"path": {"type": "string"}},
+                      "required": ["path"]}},
+]
+
+
+def run(goal: str, max_steps: int = 8):
+    client = anthropic.Anthropic()  # uses ANTHROPIC_API_KEY
+    messages = [{"role": "user", "content": goal}]
+
+    for step in range(max_steps):   # <- this loop is what makes it an agent
+        resp = client.messages.create(
+            model="claude-sonnet-4-5", max_tokens=1024,
+            tools=TOOLS, messages=messages)
+        messages.append({"role": "assistant", "content": resp.content})
+
+        if resp.stop_reason != "tool_use":   # final answer -> stop
+            return "".join(b.text for b in resp.content if b.type == "text")
+
+        results = []
+        for block in resp.content:           # execute tool calls -> observe
+            if block.type == "tool_use":
+                out = TOOLS_IMPL[block.name](**block.input)
+                print(f"  [tool] {block.name}({block.input}) -> {out}")
+                results.append({"type": "tool_result",
+                                "tool_use_id": block.id, "content": str(out)})
+        messages.append({"role": "user", "content": results})
+
+    return "stopped: max steps exceeded"   # the stop condition is a safety net
+
+
+if __name__ == "__main__":
+    goal = sys.argv[1] if len(sys.argv) > 1 else \
+        "Read notes.txt and sum the numbers in it."
+    print(run(goal))

--- a/submissions/25622005/week-01/first_agent.py
+++ b/submissions/25622005/week-01/first_agent.py
@@ -1,12 +1,14 @@
-"""Week 01 starter — the agent from the lab, Anthropic API version.
+"""Week 01 submission — the agent from the lab, Anthropic API version.
 
-Two tools: calculator, read_file. Your assignment: add a third.
+Three tools: calculator, read_file, clock. Third tool added for the assignment.
 Requires: pip install anthropic, and ANTHROPIC_API_KEY in the environment.
 """
 import os
 import sys
 import ast
+import time
 import operator
+from datetime import datetime, timezone
 
 import anthropic
 
@@ -41,7 +43,14 @@ def read_file(path: str) -> str:
         return f.read()[:4000]
 
 
-TOOLS_IMPL = {"calculator": calculator, "read_file": read_file}
+# ---- tool 3: clock (current time, for self-timing) ----
+def clock() -> str:
+    """Return the current time as an ISO 8601 UTC timestamp plus a unix epoch."""
+    now = datetime.now(timezone.utc)
+    return f"{now.isoformat()} (unix={time.time():.3f})"
+
+
+TOOLS_IMPL = {"calculator": calculator, "read_file": read_file, "clock": clock}
 
 # ---- tool schemas handed to the model (the description IS the interface) ----
 TOOLS = [
@@ -55,6 +64,12 @@ TOOLS = [
      "input_schema": {"type": "object",
                       "properties": {"path": {"type": "string"}},
                       "required": ["path"]}},
+    {"name": "clock",
+     "description": ("Return the current time as an ISO 8601 UTC timestamp and a "
+                      "unix epoch in seconds. Call it once before and once after a "
+                      "task to compute how many seconds the task took, by "
+                      "subtracting the two unix epoch values."),
+     "input_schema": {"type": "object", "properties": {}, "required": []}},
 ]
 
 
@@ -84,6 +99,9 @@ def run(goal: str, max_steps: int = 8):
 
 
 if __name__ == "__main__":
-    goal = sys.argv[1] if len(sys.argv) > 1 else \
-        "Read notes.txt and sum the numbers in it."
+    goal = sys.argv[1] if len(sys.argv) > 1 else (
+        "Call clock, then read notes.txt and sum the numbers in it, then call "
+        "clock again. Report the total and how many seconds elapsed between "
+        "your two clock calls."
+    )
     print(run(goal))

--- a/submissions/25622005/week-01/first_agent.py
+++ b/submissions/25622005/week-01/first_agent.py
@@ -1,7 +1,7 @@
 """Week 01 submission — OpenAI-compatible API version (works with OpenRouter).
 
 Three tools: calculator, read_file, clock. Third tool added for the assignment.
-Requires: pip install openai, and in the environment:
+Requires: pip install openai python-dotenv, and in .env or the environment:
   OPENAI_API_KEY   your key (an OpenRouter key works)
   OPENAI_BASE_URL  optional; set to https://openrouter.ai/api/v1 for OpenRouter
   AGENT_MODEL      optional; defaults to gpt-4o-mini. For OpenRouter free
@@ -15,7 +15,10 @@ import time
 import operator
 from datetime import datetime, timezone
 
+from dotenv import load_dotenv
 from openai import OpenAI
+
+load_dotenv()  # picks up OPENAI_API_KEY / OPENAI_BASE_URL / AGENT_MODEL from .env
 
 # ---- tool 1: calculator (safe, no eval) ----
 _OPS = {ast.Add: operator.add, ast.Sub: operator.sub,

--- a/submissions/25622005/week-01/first_agent.py
+++ b/submissions/25622005/week-01/first_agent.py
@@ -1,6 +1,6 @@
-"""Week 01 starter — OpenAI-compatible API version (works with OpenRouter).
+"""Week 01 submission — OpenAI-compatible API version (works with OpenRouter).
 
-Two tools: calculator, read_file. Your assignment: add a third.
+Three tools: calculator, read_file, clock. Third tool added for the assignment.
 Requires: pip install openai, and in the environment:
   OPENAI_API_KEY   your key (an OpenRouter key works)
   OPENAI_BASE_URL  optional; set to https://openrouter.ai/api/v1 for OpenRouter
@@ -11,7 +11,9 @@ import os
 import sys
 import ast
 import json
+import time
 import operator
+from datetime import datetime, timezone
 
 from openai import OpenAI
 
@@ -46,7 +48,14 @@ def read_file(path: str) -> str:
         return f.read()[:4000]
 
 
-TOOLS_IMPL = {"calculator": calculator, "read_file": read_file}
+# ---- tool 3: clock (current time, for self-timing) ----
+def clock() -> str:
+    """Return the current time as an ISO 8601 UTC timestamp plus a unix epoch."""
+    now = datetime.now(timezone.utc)
+    return f"{now.isoformat()} (unix={time.time():.3f})"
+
+
+TOOLS_IMPL = {"calculator": calculator, "read_file": read_file, "clock": clock}
 
 # ---- tool schemas handed to the model (the description IS the interface) ----
 TOOLS = [
@@ -64,6 +73,14 @@ TOOLS = [
          "parameters": {"type": "object",
                         "properties": {"path": {"type": "string"}},
                         "required": ["path"]}}},
+    {"type": "function",
+     "function": {
+         "name": "clock",
+         "description": ("Return the current time as an ISO 8601 UTC timestamp and a "
+                          "unix epoch in seconds. Call it once before and once after a "
+                          "task to compute how many seconds the task took, by "
+                          "subtracting the two unix epoch values."),
+         "parameters": {"type": "object", "properties": {}, "required": []}}},
 ]
 
 MODEL = os.environ.get("AGENT_MODEL", "gpt-4o-mini")
@@ -93,6 +110,9 @@ def run(goal: str, max_steps: int = 8):
 
 
 if __name__ == "__main__":
-    goal = sys.argv[1] if len(sys.argv) > 1 else \
-        "Read notes.txt and sum the numbers in it."
+    goal = sys.argv[1] if len(sys.argv) > 1 else (
+        "Call clock, then read notes.txt and sum the numbers in it, then call "
+        "clock again. Report the total and how many seconds elapsed between "
+        "your two clock calls."
+    )
     print(run(goal))

--- a/submissions/25622005/week-01/first_agent.py
+++ b/submissions/25622005/week-01/first_agent.py
@@ -1,16 +1,19 @@
-"""Week 01 submission — the agent from the lab, Anthropic API version.
+"""Week 01 starter — OpenAI-compatible API version (works with OpenRouter).
 
-Three tools: calculator, read_file, clock. Third tool added for the assignment.
-Requires: pip install anthropic, and ANTHROPIC_API_KEY in the environment.
+Two tools: calculator, read_file. Your assignment: add a third.
+Requires: pip install openai, and in the environment:
+  OPENAI_API_KEY   your key (an OpenRouter key works)
+  OPENAI_BASE_URL  optional; set to https://openrouter.ai/api/v1 for OpenRouter
+  AGENT_MODEL      optional; defaults to gpt-4o-mini. For OpenRouter free
+                   models use e.g. AGENT_MODEL=meta-llama/llama-3.3-70b-instruct:free
 """
 import os
 import sys
 import ast
-import time
+import json
 import operator
-from datetime import datetime, timezone
 
-import anthropic
+from openai import OpenAI
 
 # ---- tool 1: calculator (safe, no eval) ----
 _OPS = {ast.Add: operator.add, ast.Sub: operator.sub,
@@ -43,65 +46,53 @@ def read_file(path: str) -> str:
         return f.read()[:4000]
 
 
-# ---- tool 3: clock (current time, for self-timing) ----
-def clock() -> str:
-    """Return the current time as an ISO 8601 UTC timestamp plus a unix epoch."""
-    now = datetime.now(timezone.utc)
-    return f"{now.isoformat()} (unix={time.time():.3f})"
-
-
-TOOLS_IMPL = {"calculator": calculator, "read_file": read_file, "clock": clock}
+TOOLS_IMPL = {"calculator": calculator, "read_file": read_file}
 
 # ---- tool schemas handed to the model (the description IS the interface) ----
 TOOLS = [
-    {"name": "calculator",
-     "description": "Evaluate an arithmetic expression.",
-     "input_schema": {"type": "object",
-                      "properties": {"expression": {"type": "string"}},
-                      "required": ["expression"]}},
-    {"name": "read_file",
-     "description": "Read a text file in the working directory.",
-     "input_schema": {"type": "object",
-                      "properties": {"path": {"type": "string"}},
-                      "required": ["path"]}},
-    {"name": "clock",
-     "description": ("Return the current time as an ISO 8601 UTC timestamp and a "
-                      "unix epoch in seconds. Call it once before and once after a "
-                      "task to compute how many seconds the task took, by "
-                      "subtracting the two unix epoch values."),
-     "input_schema": {"type": "object", "properties": {}, "required": []}},
+    {"type": "function",
+     "function": {
+         "name": "calculator",
+         "description": "Evaluate an arithmetic expression.",
+         "parameters": {"type": "object",
+                        "properties": {"expression": {"type": "string"}},
+                        "required": ["expression"]}}},
+    {"type": "function",
+     "function": {
+         "name": "read_file",
+         "description": "Read a text file in the working directory.",
+         "parameters": {"type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"]}}},
 ]
+
+MODEL = os.environ.get("AGENT_MODEL", "gpt-4o-mini")
 
 
 def run(goal: str, max_steps: int = 8):
-    client = anthropic.Anthropic()  # uses ANTHROPIC_API_KEY
+    client = OpenAI()  # uses OPENAI_API_KEY and OPENAI_BASE_URL
     messages = [{"role": "user", "content": goal}]
 
     for step in range(max_steps):   # <- this loop is what makes it an agent
-        resp = client.messages.create(
-            model="claude-sonnet-4-5", max_tokens=1024,
-            tools=TOOLS, messages=messages)
-        messages.append({"role": "assistant", "content": resp.content})
+        resp = client.chat.completions.create(
+            model=MODEL, tools=TOOLS, messages=messages)
+        msg = resp.choices[0].message
+        messages.append(msg)
 
-        if resp.stop_reason != "tool_use":   # final answer -> stop
-            return "".join(b.text for b in resp.content if b.type == "text")
+        if not msg.tool_calls:               # final answer -> stop
+            return msg.content or ""
 
-        results = []
-        for block in resp.content:           # execute tool calls -> observe
-            if block.type == "tool_use":
-                out = TOOLS_IMPL[block.name](**block.input)
-                print(f"  [tool] {block.name}({block.input}) -> {out}")
-                results.append({"type": "tool_result",
-                                "tool_use_id": block.id, "content": str(out)})
-        messages.append({"role": "user", "content": results})
+        for call in msg.tool_calls:          # execute tool calls -> observe
+            args = json.loads(call.function.arguments)
+            out = TOOLS_IMPL[call.function.name](**args)
+            print(f"  [tool] {call.function.name}({args}) -> {out}")
+            messages.append({"role": "tool", "tool_call_id": call.id,
+                             "content": str(out)})
 
     return "stopped: max steps exceeded"   # the stop condition is a safety net
 
 
 if __name__ == "__main__":
-    goal = sys.argv[1] if len(sys.argv) > 1 else (
-        "Call clock, then read notes.txt and sum the numbers in it, then call "
-        "clock again. Report the total and how many seconds elapsed between "
-        "your two clock calls."
-    )
+    goal = sys.argv[1] if len(sys.argv) > 1 else \
+        "Read notes.txt and sum the numbers in it."
     print(run(goal))

--- a/submissions/25622005/week-01/logs/trial-01.log
+++ b/submissions/25622005/week-01/logs/trial-01.log
@@ -1,0 +1,24 @@
+  [tool] clock({}) -> 2026-09-06T12:55:58.979639+00:00 (unix=1788699358.980)
+  [tool] read_file({'path': 'notes.txt'}) -> Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.
+
+  [tool] clock({}) -> 2026-09-06T12:56:03.684458+00:00 (unix=1788699363.684)
+  [tool] calculator({'expression': '4 + 48000 + 9500 + 12000'}) -> 69504
+I have completed the requested task. Here's the summary:
+
+**Total from notes.txt:** 69,504
+- Attendees: 4
+- Pizza budget: 48,000
+- Drinks: 9,500
+- Reimbursed so far: 12,000
+- **Sum: 69,504**
+
+**Elapsed time:** 4.704 seconds
+
+The task took approximately 4.704 seconds between the initial and final clock calls.

--- a/submissions/25622005/week-01/logs/trial-02.log
+++ b/submissions/25622005/week-01/logs/trial-02.log
@@ -1,0 +1,18 @@
+  [tool] clock({}) -> 2026-09-06T12:56:26.740477+00:00 (unix=1788699386.740)
+  [tool] read_file({'path': 'notes.txt'}) -> Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.
+
+  [tool] calculator({'expression': '4+48000+9500+12000'}) -> 69504
+  [tool] clock({}) -> 2026-09-06T12:56:29.828352+00:00 (unix=1788699389.828)
+  [tool] calculator({'expression': '1788699389.828 - 1788699386.740'}) -> 3.0880000591278076
+
+
+The total sum is **69504**.
+
+The elapsed time between the two clock calls was approximately **3.088 seconds**.

--- a/submissions/25622005/week-01/notes.txt
+++ b/submissions/25622005/week-01/notes.txt
@@ -1,0 +1,8 @@
+Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.


### PR DESCRIPTION
<!-- Title format: [week-NN] <student-id>   (or [roster] <student-id>) -->

## What I built

An agent with three tools — `calculator`, `read_file`, and a new `clock` — that reads `notes.txt`, sums the numbers in it, and reports both the total and how many seconds the run took, by calling `clock` before and after the task and subtracting the two unix-epoch values.

## What I tried and discarded

- Started from the Anthropic-client starter (as built in the lab) and added `clock` there first — visible in the early commits. Switched to the OpenAI-compatible starter afterward because I'm running against OpenRouter, not Anthropic directly, and re-ported the same `clock` tool onto that base.
- Tried `qwen/qwen3.6-plus-preview:free` and `z-ai/glm-5.2:free` as the model, based on what search results and OpenRouter's collections page showed. Both returned `404 No endpoints found` at run time — those free variants no longer exist / aren't actually being served, despite appearing in cached listings. Settled on `openrouter/free`, OpenRouter's own free-model router, instead.
- Initially relied on `uv run --env-file` to load `.env`; switched to loading it in-code with `python-dotenv` so the script doesn't depend on how it's invoked.

## How to run
- Pre-requsite
  - python version: 3.12
  - used package manager: uv
  - pyproject.toml (not committed because it's not permitted directory for student.)
    ```bash
    [project]
    name = "ai-agent-engineering-101"
    version = "0.1.0"
    description = "Add your description here"
    readme = "README.md"
    requires-python = ">=3.12"
    dependencies = [
        "dotenv>=0.9.9",
        "openai>=3.8.0",
    ]
    ```
- Model: `openrouter/free` (OpenRouter's free-models router — auto-selects among free, tool-calling-capable models)
- Env vars (in `.env`, not committed): `OPENAI_API_KEY=<your OpenRouter key>`, `OPENAI_BASE_URL=https://openrouter.ai/api/v1`, `AGENT_MODEL=openrouter/free`
- Command:
  ```bash
  cd submissions/25622005/week-01
  uv run --with openai --with python-dotenv python first_agent.py 2>&1 | tee logs/trial-XX.txt
