### PR TITLE
[week-01] 25512084

### DIFF
--- a/submissions/25512084/week-01/TOOLS.md
+++ b/submissions/25512084/week-01/TOOLS.md
@@ -1,0 +1,1 @@
+It says what information the tool provides and when it can be used. The result comes from the machine's local time zone.

--- a/submissions/25512084/week-01/first_agent.py
+++ b/submissions/25512084/week-01/first_agent.py
@@ -1,0 +1,111 @@
+"""Week 01 starter — OpenAI-compatible API version (works with OpenRouter).
+
+Two tools: calculator, read_file. Your assignment: add a third.
+Requires: pip install openai, and in the environment:
+  OPENAI_API_KEY   your key (an OpenRouter key works)
+  OPENAI_BASE_URL  optional; set to https://openrouter.ai/api/v1 for OpenRouter
+  AGENT_MODEL      optional; defaults to gpt-4o-mini. For OpenRouter free
+                   models use e.g. AGENT_MODEL=meta-llama/llama-3.3-70b-instruct:free
+"""
+import os
+import sys
+import ast
+import json
+import operator
+
+from openai import OpenAI
+
+# ---- tool 1: calculator (safe, no eval) ----
+_OPS = {ast.Add: operator.add, ast.Sub: operator.sub,
+        ast.Mult: operator.mul, ast.Div: operator.truediv,
+        ast.Pow: operator.pow, ast.USub: operator.neg}
+
+
+def _ev(node):
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.BinOp):
+        return _OPS[type(node.op)](_ev(node.left), _ev(node.right))
+    if isinstance(node, ast.UnaryOp):
+        return _OPS[type(node.op)](_ev(node.operand))
+    raise ValueError("expression not allowed")
+
+
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression string, e.g. '3 * (4 + 5)'."""
+    return str(_ev(ast.parse(expression, mode="eval").body))
+
+
+# ---- tool 2: read_file (blocked outside the working directory) ----
+def read_file(path: str) -> str:
+    """Return the contents of a text file."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    with open(full, encoding="utf-8") as f:
+        return f.read()[:4000]
+
+# ---- tool 3: clock ----
+def clock() -> str:
+    """Return the current local date and time."""
+    from datetime import datetime
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+TOOLS_IMPL = {"calculator": calculator, "read_file": read_file, "clock": clock}
+
+# ---- tool schemas handed to the model (the description IS the interface) ----
+TOOLS = [
+    {"type": "function",
+     "function": {
+         "name": "calculator",
+         "description": "Evaluate an arithmetic expression.",
+         "parameters": {"type": "object",
+                        "properties": {"expression": {"type": "string"}},
+                        "required": ["expression"]}}},
+    {"type": "function",
+     "function": {
+         "name": "read_file",
+         "description": "Read a text file in the working directory.",
+         "parameters": {"type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"]}}},
+    {"type": "function",
+     "function": {
+         "name": "clock",
+         "description": "Return the current local date and time.",
+         "parameters": {
+             "type": "object",
+             "properties": {}
+         }}},
+]
+
+MODEL = os.environ.get("AGENT_MODEL", "gpt-4o-mini")
+
+
+def run(goal: str, max_steps: int = 8):
+    client = OpenAI()  # uses OPENAI_API_KEY and OPENAI_BASE_URL
+    messages = [{"role": "user", "content": goal}]
+
+    for step in range(max_steps):   # <- this loop is what makes it an agent
+        resp = client.chat.completions.create(
+            model=MODEL, tools=TOOLS, messages=messages)
+        msg = resp.choices[0].message
+        messages.append(msg)
+
+        if not msg.tool_calls:               # final answer -> stop
+            return msg.content or ""
+
+        for call in msg.tool_calls:          # execute tool calls -> observe
+            args = json.loads(call.function.arguments)
+            out = TOOLS_IMPL[call.function.name](**args)
+            print(f"  [tool] {call.function.name}({args}) -> {out}")
+            messages.append({"role": "tool", "tool_call_id": call.id,
+                             "content": str(out)})
+
+    return "stopped: max steps exceeded"   # the stop condition is a safety net
+
+
+if __name__ == "__main__":
+    goal = sys.argv[1] if len(sys.argv) > 1 else \
+        "Read notes.txt and sum the numbers in it."
+    print(run(goal))

--- a/submissions/25512084/week-01/logs/guardrail-maxsteps.txt
+++ b/submissions/25512084/week-01/logs/guardrail-maxsteps.txt
@@ -1,0 +1,1 @@
+stopped: max steps exceeded

--- a/submissions/25512084/week-01/logs/guardrail-path.txt
+++ b/submissions/25512084/week-01/logs/guardrail-path.txt
@@ -1,0 +1,1 @@
+denied: path outside the working directory

--- a/submissions/25512084/week-01/logs/run-01.txt
+++ b/submissions/25512084/week-01/logs/run-01.txt
@@ -1,0 +1,14 @@
+Traceback (most recent call last):
+  File "/Users/dariakolotihina/Documents/ai-agent-engineering-101/submissions/25512084/week-01/first_agent.py", line 111, in <module>
+    print(run(goal))
+  File "/Users/dariakolotihina/Documents/ai-agent-engineering-101/submissions/25512084/week-01/first_agent.py", line 90, in run
+    resp = client.chat.completions.create(
+  File "/Users/dariakolotihina/Library/Python/3.9/lib/python/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+  File "/Users/dariakolotihina/Library/Python/3.9/lib/python/site-packages/openai/resources/chat/completions/completions.py", line 1284, in create
+    return self._post(
+  File "/Users/dariakolotihina/Library/Python/3.9/lib/python/site-packages/openai/_base_client.py", line 1360, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+  File "/Users/dariakolotihina/Library/Python/3.9/lib/python/site-packages/openai/_base_client.py", line 1133, in request
+    raise self._make_status_error_from_response(err.response) from None
+openai.NotFoundError: Error code: 404 - {'error': {'message': 'This model is unavailable for free. The paid version is available now - use this slug instead: meta-llama/llama-3.3-70b-instruct', 'code': 404}, 'user_id': 'user_3IiuejAjlhj36aodSVQ8pjf4qRC'}

--- a/submissions/25512084/week-01/logs/run-02.txt
+++ b/submissions/25512084/week-01/logs/run-02.txt
@@ -1,0 +1,19 @@
+  [tool] read_file({'path': 'notes.txt'}) -> Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.
+
+  [tool] calculator({'expression': '2026 + 4 + 48000 + 9500 + 12000'}) -> 71530
+I've read **notes.txt** and found the following numbers:
+
+- 2026 (meeting date)  
+- 4 (attendees)  
+- 48,000 (pizza budget)  
+- 9,500 (drinks)  
+- 12,000 (reimbursed so far)
+
+**Sum:** 2026 + 4 + 48,000 + 9,500 + 12,000 = **71,530**.

--- a/submissions/25512084/week-01/logs/run-03.txt
+++ b/submissions/25512084/week-01/logs/run-03.txt
@@ -1,0 +1,14 @@
+  [tool] read_file({'path': 'notes.txt'}) -> Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.
+
+  [tool] calculator({'expression': '4 + 48000 + 9500 + 12000'}) -> 69504
+  [tool] clock({}) -> 2026-09-06T23:19:39+09:00
+The sum of the numbers in `notes.txt` (4 + 48,000 + 9,500 + 12,000) is **69,504**.
+
+The current local date and time is **2026-09-06T23:19:39+09:00**.

--- a/submissions/25512084/week-01/notes.txt
+++ b/submissions/25512084/week-01/notes.txt
@@ -1,0 +1,8 @@
+Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.


### PR DESCRIPTION
- **BAdd week 01 agent with clock tool**
- **Add week 01 agent run logs**
- **Add guardrail test logs**

<!-- Title format: [week-NN] <student-id>   (or [roster] <student-id>) --> 25512084

## What I built

<!-- One or two sentences. For week assignments: what task did your agent solve? -->I added a clock tool to the starter  agent. The agent can read notes.txt, calculate the total, and report the current local date and time.

## What I tried and discarded

<!-- Honest notes. Failed approaches, tools you removed, prompts that didn't work.
     This is graded material — the messier the truth, the better. --> The first run failed because the example free model was no longer available on OpenRouter. I changed AGENT_MODEL to openrouter/free. In another run, the agent incorrectly included 2026 from the date in the calculation; the next run correctly selected the relevant numbers and used all three tools.

## How to run

<!-- Model name, env vars (never the key itself), exact command. --> Model: openrouter/free
Environment: OPENAI_API_KEY and OPENAI_BASE_URL=https://openrouter.ai/api/v1
Command: python3 first_agent.py "Read notes.txt, calculate the total, and also report the current local date and time

## Checklist

- [x] `python scripts/check_week01.py submissions/25512084/week-01` passes locally (skip for roster PRs)
- [x] Run logs are committed under `logs/`
- [x] No API keys anywhere in the diff
- [x] History is not squashed
