### PR TITLE
[week-01] 25620027

### DIFF
--- a/roster/25620027.md
+++ b/roster/25620027.md
@@ -1,0 +1,4 @@
+# 25620027
+
+- github: SungJinho
+- name: 성진호

--- a/submissions/25620027/week-01/TOOLS.md
+++ b/submissions/25620027/week-01/TOOLS.md
@@ -7,15 +7,15 @@
 - 기준 API: OpenAI API
 - 요청 모델 ID: `gpt-5-mini`
 - 성공 로그에서 확인된 실제 모델 ID: `gpt-5-mini-2025-08-07`
-- Python 의존성: `openai`
+- Python 의존성: `openai==3.7.0`
 - 실행 위치: 이 디렉터리
-- 도구 스키마: `calculator(expression: string)`, `read_file(path: string)`, `text_stats(text: string)`이며 세 인자는 모두 필수다. 전체 JSON 스키마는 `first_agent.py`의 `TOOLS`에 있다.
+- 도구 스키마: `calculator(expression: string)`, `read_file(path: "notes.txt")`, `text_stats(text: string)`이며 세 인자는 모두 필수다. `read_file`은 과제 입력인 `notes.txt`만 허용해 환경변수 파일 같은 다른 로컬 파일이 모델에 전달되지 않게 한다. 전체 JSON 스키마는 `first_agent.py`의 `TOOLS`에 있다.
 
 ```bash
 export OPENAI_BASE_URL=https://api.openai.com/v1
 export OPENAI_API_KEY=<your OpenAI API key>
 export AGENT_MODEL=gpt-5-mini
-uv run --isolated --with openai python first_agent.py 2>&1 | tee logs/run-openai-01.txt
+uv run --isolated --with openai==3.7.0 python first_agent.py 2>&1 | tee logs/run-openai-01.txt
 ```
 
 API 키는 파일이나 저장소에 넣지 않고 실행할 터미널의 환경변수로만 전달한다. 프로그램은 첫 응답의 실제 모델 ID를 `[model]` 줄로 출력하므로 모델 별칭이 어떤 버전으로 처리됐는지 로그에서 확인할 수 있다.

--- a/submissions/25620027/week-01/TOOLS.md
+++ b/submissions/25620027/week-01/TOOLS.md
@@ -9,7 +9,7 @@
 - 성공 로그에서 확인된 실제 모델 ID: `gpt-5-mini-2025-08-07`
 - Python 의존성: `openai==3.7.0`
 - 실행 위치: 이 디렉터리
-- 도구 스키마: `calculator(expression: string)`, `read_file(path: "notes.txt")`, `text_stats(text: string)`이며 세 인자는 모두 필수다. `read_file`은 과제 입력인 `notes.txt`만 허용해 환경변수 파일 같은 다른 로컬 파일이 모델에 전달되지 않게 한다. 전체 JSON 스키마는 `first_agent.py`의 `TOOLS`에 있다.
+- 도구 스키마: `calculator(expression: string)`, `read_file(path: "notes.txt")`, `text_stats(text: string)`이며 세 인자는 모두 필수다. `calculator`는 입력 길이·수식 크기·숫자와 지수 범위를 제한하고, `read_file`은 과제 입력인 `notes.txt`만 허용해 환경변수 파일 같은 다른 로컬 파일이 모델에 전달되지 않게 한다. 전체 JSON 스키마는 `first_agent.py`의 `TOOLS`에 있다.
 
 ```bash
 export OPENAI_BASE_URL=https://api.openai.com/v1

--- a/submissions/25620027/week-01/TOOLS.md
+++ b/submissions/25620027/week-01/TOOLS.md
@@ -4,16 +4,22 @@
 
 ## Reproduce
 
-- API: OpenRouter의 OpenAI 호환 API
-- 모델 ID: `openrouter/free` (도구 호출 요구를 지원하는 무료 모델로 라우팅)
+- 기준 API: OpenAI API
+- 요청 모델 ID: `gpt-5-mini`
+- 성공 로그에서 확인된 실제 모델 ID: `gpt-5-mini-2025-08-07`
 - Python 의존성: `openai`
 - 실행 위치: 이 디렉터리
+- 도구 스키마: `calculator(expression: string)`, `read_file(path: string)`, `text_stats(text: string)`이며 세 인자는 모두 필수다. 전체 JSON 스키마는 `first_agent.py`의 `TOOLS`에 있다.
 
 ```bash
-export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-export OPENAI_API_KEY=<your OpenRouter API key>
-export AGENT_MODEL=openrouter/free
-uv run --isolated --with openai python first_agent.py 2>&1 | tee logs/run-01.txt
+export OPENAI_BASE_URL=https://api.openai.com/v1
+export OPENAI_API_KEY=<your OpenAI API key>
+export AGENT_MODEL=gpt-5-mini
+uv run --isolated --with openai python first_agent.py 2>&1 | tee logs/run-openai-01.txt
 ```
 
-`openrouter/free`는 실행 시점에 무료 모델을 선택하므로, 프로그램은 첫 응답의 실제 모델 ID를 `[model]` 줄로 로그에 기록한다.
+API 키는 파일이나 저장소에 넣지 않고 실행할 터미널의 환경변수로만 전달한다. 프로그램은 첫 응답의 실제 모델 ID를 `[model]` 줄로 출력하므로 모델 별칭이 어떤 버전으로 처리됐는지 로그에서 확인할 수 있다.
+
+## Observation
+
+두 성공 실행 모두 모델이 `read_file` → `text_stats` → `calculator` 순서로 세 도구를 선택했고 비용 계산 결과는 `45500`으로 같았다. 다만 OpenRouter가 선택한 `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`는 읽은 내용을 `text_stats`에 다시 전달할 때 마지막 줄바꿈을 제외해 237자로 계산했고(`logs/run-03.txt`), OpenAI의 `gpt-5-mini-2025-08-07`은 마지막 줄바꿈까지 전달해 원본과 같은 238자로 계산했다(`logs/run-openai-01.txt`). 이는 세 번째 도구를 고르는 순서는 같아도, 모델에 따라 앞 도구의 결과를 다음 도구의 인자로 보존하는 정확도가 달라질 수 있음을 보여준다.

--- a/submissions/25620027/week-01/TOOLS.md
+++ b/submissions/25620027/week-01/TOOLS.md
@@ -1,0 +1,19 @@
+# Tool-description rationale
+
+새 도구 `text_stats`의 설명을 “Count words, lines, and characters in supplied text. Pass file contents, not a path; call read_file first.”로 작성했다. 첫 문장은 이 도구가 반환하는 결과를 구체적으로 한정해 계산기와의 역할 중복을 피하고, 두 번째 문장은 모델이 파일 경로를 잘못 전달하지 않도록 입력의 의미를 명시한다. 특히 `read_file`을 먼저 호출하라는 문구는 파일을 읽은 결과를 `text_stats`에 넘기는 순서를 알려 주되, 최종 답을 직접 지시하지 않으므로 모델이 세 도구 중 필요한 도구를 선택하는 행동을 관찰할 수 있게 한다.
+
+## Reproduce
+
+- API: OpenRouter의 OpenAI 호환 API
+- 모델 ID: `openrouter/free` (도구 호출 요구를 지원하는 무료 모델로 라우팅)
+- Python 의존성: `openai`
+- 실행 위치: 이 디렉터리
+
+```bash
+export OPENAI_BASE_URL=https://openrouter.ai/api/v1
+export OPENAI_API_KEY=<your OpenRouter API key>
+export AGENT_MODEL=openrouter/free
+uv run --isolated --with openai python first_agent.py 2>&1 | tee logs/run-01.txt
+```
+
+`openrouter/free`는 실행 시점에 무료 모델을 선택하므로, 프로그램은 첫 응답의 실제 모델 ID를 `[model]` 줄로 로그에 기록한다.

--- a/submissions/25620027/week-01/first_agent.py
+++ b/submissions/25620027/week-01/first_agent.py
@@ -1,0 +1,98 @@
+"""Week 01 starter — OpenAI-compatible API version (works with OpenRouter).
+
+Two tools: calculator, read_file. Your assignment: add a third.
+Requires: pip install openai, and in the environment:
+  OPENAI_API_KEY   your key (an OpenRouter key works)
+  OPENAI_BASE_URL  optional; set to https://openrouter.ai/api/v1 for OpenRouter
+  AGENT_MODEL      optional; defaults to gpt-4o-mini. For OpenRouter free
+                   models use e.g. AGENT_MODEL=meta-llama/llama-3.3-70b-instruct:free
+"""
+import os
+import sys
+import ast
+import json
+import operator
+
+from openai import OpenAI
+
+# ---- tool 1: calculator (safe, no eval) ----
+_OPS = {ast.Add: operator.add, ast.Sub: operator.sub,
+        ast.Mult: operator.mul, ast.Div: operator.truediv,
+        ast.Pow: operator.pow, ast.USub: operator.neg}
+
+
+def _ev(node):
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.BinOp):
+        return _OPS[type(node.op)](_ev(node.left), _ev(node.right))
+    if isinstance(node, ast.UnaryOp):
+        return _OPS[type(node.op)](_ev(node.operand))
+    raise ValueError("expression not allowed")
+
+
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression string, e.g. '3 * (4 + 5)'."""
+    return str(_ev(ast.parse(expression, mode="eval").body))
+
+
+# ---- tool 2: read_file (blocked outside the working directory) ----
+def read_file(path: str) -> str:
+    """Return the contents of a text file."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    with open(full, encoding="utf-8") as f:
+        return f.read()[:4000]
+
+
+TOOLS_IMPL = {"calculator": calculator, "read_file": read_file}
+
+# ---- tool schemas handed to the model (the description IS the interface) ----
+TOOLS = [
+    {"type": "function",
+     "function": {
+         "name": "calculator",
+         "description": "Evaluate an arithmetic expression.",
+         "parameters": {"type": "object",
+                        "properties": {"expression": {"type": "string"}},
+                        "required": ["expression"]}}},
+    {"type": "function",
+     "function": {
+         "name": "read_file",
+         "description": "Read a text file in the working directory.",
+         "parameters": {"type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"]}}},
+]
+
+MODEL = os.environ.get("AGENT_MODEL", "gpt-4o-mini")
+
+
+def run(goal: str, max_steps: int = 8):
+    client = OpenAI()  # uses OPENAI_API_KEY and OPENAI_BASE_URL
+    messages = [{"role": "user", "content": goal}]
+
+    for step in range(max_steps):   # <- this loop is what makes it an agent
+        resp = client.chat.completions.create(
+            model=MODEL, tools=TOOLS, messages=messages)
+        msg = resp.choices[0].message
+        messages.append(msg)
+
+        if not msg.tool_calls:               # final answer -> stop
+            return msg.content or ""
+
+        for call in msg.tool_calls:          # execute tool calls -> observe
+            args = json.loads(call.function.arguments)
+            out = TOOLS_IMPL[call.function.name](**args)
+            print(f"  [tool] {call.function.name}({args}) -> {out}")
+            messages.append({"role": "tool", "tool_call_id": call.id,
+                             "content": str(out)})
+
+    return "stopped: max steps exceeded"   # the stop condition is a safety net
+
+
+if __name__ == "__main__":
+    goal = sys.argv[1] if len(sys.argv) > 1 else \
+        "Read notes.txt and sum the numbers in it."
+    print(run(goal))

--- a/submissions/25620027/week-01/first_agent.py
+++ b/submissions/25620027/week-01/first_agent.py
@@ -11,6 +11,7 @@ import os
 import sys
 import ast
 import json
+import math
 import operator
 from pathlib import Path
 
@@ -21,21 +22,48 @@ _OPS = {ast.Add: operator.add, ast.Sub: operator.sub,
         ast.Mult: operator.mul, ast.Div: operator.truediv,
         ast.Pow: operator.pow, ast.USub: operator.neg}
 _READABLE_FILES = {"notes.txt"}
+_MAX_EXPRESSION_LENGTH = 100
+_MAX_AST_NODES = 50
+_MAX_ABS_VALUE = 10 ** 12
+_MAX_EXPONENT = 10
+
+
+def _checked_number(value):
+    if (type(value) not in (int, float)
+            or abs(value) > _MAX_ABS_VALUE
+            or not math.isfinite(value)):
+        raise ValueError("number outside allowed range")
+    return value
 
 
 def _ev(node):
     if isinstance(node, ast.Constant):
-        return node.value
+        return _checked_number(node.value)
     if isinstance(node, ast.BinOp):
-        return _OPS[type(node.op)](_ev(node.left), _ev(node.right))
+        op_type = type(node.op)
+        if op_type not in _OPS:
+            raise ValueError("expression not allowed")
+        left = _ev(node.left)
+        right = _ev(node.right)
+        if op_type is ast.Pow and abs(right) > _MAX_EXPONENT:
+            raise ValueError("exponent outside allowed range")
+        return _checked_number(_OPS[op_type](left, right))
     if isinstance(node, ast.UnaryOp):
-        return _OPS[type(node.op)](_ev(node.operand))
+        op_type = type(node.op)
+        if op_type not in _OPS:
+            raise ValueError("expression not allowed")
+        return _checked_number(_OPS[op_type](_ev(node.operand)))
     raise ValueError("expression not allowed")
 
 
 def calculator(expression: str) -> str:
-    """Evaluate an arithmetic expression string, e.g. '3 * (4 + 5)'."""
-    return str(_ev(ast.parse(expression, mode="eval").body))
+    """Evaluate a bounded arithmetic expression, e.g. '3 * (4 + 5)'."""
+    if len(expression) > _MAX_EXPRESSION_LENGTH:
+        raise ValueError("expression too long")
+    tree = ast.parse(expression, mode="eval")
+    if sum(1 for _ in ast.walk(tree)) > _MAX_AST_NODES:
+        raise ValueError("expression too complex")
+    return str(_ev(tree.body))
 
 
 # ---- tool 2: read_file (blocked outside the working directory) ----
@@ -72,7 +100,7 @@ TOOLS = [
     {"type": "function",
      "function": {
          "name": "calculator",
-         "description": "Evaluate an arithmetic expression.",
+         "description": "Evaluate a basic arithmetic expression within safe limits.",
          "parameters": {"type": "object",
                         "properties": {"expression": {"type": "string"}},
                         "required": ["expression"]}}},

--- a/submissions/25620027/week-01/first_agent.py
+++ b/submissions/25620027/week-01/first_agent.py
@@ -46,7 +46,21 @@ def read_file(path: str) -> str:
         return f.read()[:4000]
 
 
-TOOLS_IMPL = {"calculator": calculator, "read_file": read_file}
+# ---- tool 3: text_stats (counts supplied text without file access) ----
+def text_stats(text: str) -> str:
+    """Return word, line, and character counts for supplied text."""
+    return json.dumps({
+        "words": len(text.split()),
+        "lines": len(text.splitlines()),
+        "characters": len(text),
+    })
+
+
+TOOLS_IMPL = {
+    "calculator": calculator,
+    "read_file": read_file,
+    "text_stats": text_stats,
+}
 
 # ---- tool schemas handed to the model (the description IS the interface) ----
 TOOLS = [
@@ -64,6 +78,14 @@ TOOLS = [
          "parameters": {"type": "object",
                         "properties": {"path": {"type": "string"}},
                         "required": ["path"]}}},
+    {"type": "function",
+     "function": {
+         "name": "text_stats",
+         "description": "Count words, lines, and characters in supplied text. "
+                        "Pass file contents, not a path; call read_file first.",
+         "parameters": {"type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"]}}},
 ]
 
 MODEL = os.environ.get("AGENT_MODEL", "gpt-4o-mini")

--- a/submissions/25620027/week-01/first_agent.py
+++ b/submissions/25620027/week-01/first_agent.py
@@ -12,6 +12,7 @@ import sys
 import ast
 import json
 import operator
+from pathlib import Path
 
 from openai import OpenAI
 
@@ -39,10 +40,11 @@ def calculator(expression: str) -> str:
 # ---- tool 2: read_file (blocked outside the working directory) ----
 def read_file(path: str) -> str:
     """Return the contents of a text file."""
-    full = os.path.abspath(path)
-    if not full.startswith(os.getcwd()):
+    working_directory = Path.cwd().resolve()
+    full = (working_directory / path).resolve()
+    if not full.is_relative_to(working_directory):
         return "denied: path outside the working directory"
-    with open(full, encoding="utf-8") as f:
+    with full.open(encoding="utf-8") as f:
         return f.read()[:4000]
 
 

--- a/submissions/25620027/week-01/first_agent.py
+++ b/submissions/25620027/week-01/first_agent.py
@@ -98,6 +98,8 @@ def run(goal: str, max_steps: int = 8):
     for step in range(max_steps):   # <- this loop is what makes it an agent
         resp = client.chat.completions.create(
             model=MODEL, tools=TOOLS, messages=messages)
+        if step == 0:
+            print(f"  [model] {resp.model}")
         msg = resp.choices[0].message
         messages.append(msg)
 
@@ -116,5 +118,6 @@ def run(goal: str, max_steps: int = 8):
 
 if __name__ == "__main__":
     goal = sys.argv[1] if len(sys.argv) > 1 else \
-        "Read notes.txt and sum the numbers in it."
+        "Read notes.txt. Use text_stats on the full contents, then use " \
+        "calculator for the requested expense arithmetic. Report both results."
     print(run(goal))

--- a/submissions/25620027/week-01/first_agent.py
+++ b/submissions/25620027/week-01/first_agent.py
@@ -20,6 +20,7 @@ from openai import OpenAI
 _OPS = {ast.Add: operator.add, ast.Sub: operator.sub,
         ast.Mult: operator.mul, ast.Div: operator.truediv,
         ast.Pow: operator.pow, ast.USub: operator.neg}
+_READABLE_FILES = {"notes.txt"}
 
 
 def _ev(node):
@@ -39,10 +40,12 @@ def calculator(expression: str) -> str:
 
 # ---- tool 2: read_file (blocked outside the working directory) ----
 def read_file(path: str) -> str:
-    """Return the contents of a text file."""
+    """Return the contents of an approved task input file."""
     working_directory = Path.cwd().resolve()
     full = (working_directory / path).resolve()
-    if not full.is_relative_to(working_directory):
+    if (not full.is_relative_to(working_directory)
+            or full.parent != working_directory
+            or full.name not in _READABLE_FILES):
         return "denied: path outside the working directory"
     with full.open(encoding="utf-8") as f:
         return f.read()[:4000]
@@ -76,9 +79,10 @@ TOOLS = [
     {"type": "function",
      "function": {
          "name": "read_file",
-         "description": "Read a text file in the working directory.",
+         "description": "Read notes.txt in the working directory.",
          "parameters": {"type": "object",
-                        "properties": {"path": {"type": "string"}},
+                        "properties": {"path": {"type": "string",
+                                                "enum": ["notes.txt"]}},
                         "required": ["path"]}}},
     {"type": "function",
      "function": {

--- a/submissions/25620027/week-01/logs/00-structural-check-before-tool.txt
+++ b/submissions/25620027/week-01/logs/00-structural-check-before-tool.txt
@@ -1,0 +1,7 @@
+ok    first_agent.py parses
+FAIL  TOOLS defines 2 tools; the assignment requires 3
+FAIL  TOOLS_IMPL maps 2 tools; the assignment requires 3
+FAIL  TOOLS.md is missing (one paragraph on why you described your new tool that way)
+ok    logs/ contains 1 file(s)
+
+3 check(s) failed

--- a/submissions/25620027/week-01/logs/run-01.txt
+++ b/submissions/25620027/week-01/logs/run-01.txt
@@ -1,0 +1,20 @@
+Installed 14 packages in 40ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/vjPxJ54WszN5sv7CKP3UT/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/vjPxJ54WszN5sv7CKP3UT/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/vjPxJ54WszN5sv7CKP3UT/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/vjPxJ54WszN5sv7CKP3UT/lib/python3.11/site-packages/openai/_base_client.py", line 1141, in request
+    raise self._make_status_error_from_response(err.response) from None
+openai.RateLimitError: Error code: 429 - {'error': {'message': 'Provider returned error', 'code': 429, 'metadata': {'raw': 'z-ai/glm-5.2:free is temporarily rate-limited upstream. Please retry shortly, or add your own key to accumulate your rate limits: https://openrouter.ai/settings/integrations', 'provider_name': 'Decart', 'is_byok': False, 'provider_error_code': 'upstream_429', 'limit_source': 'upstream_provider_shared_pool', 'remedy_hint': 'Retry shortly, add your own provider key (https://openrouter.ai/settings/integrations), or route to another provider with provider routing: https://openrouter.ai/docs/features/provider-routing', 'retry_after_seconds': 5, 'retry_after_seconds_raw': 5, 'headers': {'Retry-After': '5'}}}, 'user_id': 'user_3GqihyM3rl5T4H6NLwx0utsYquz'}

--- a/submissions/25620027/week-01/logs/run-02.txt
+++ b/submissions/25620027/week-01/logs/run-02.txt
@@ -1,0 +1,20 @@
+Installed 14 packages in 20ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/022LWiix-1knJfxorENd-/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/022LWiix-1knJfxorENd-/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/022LWiix-1knJfxorENd-/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/022LWiix-1knJfxorENd-/lib/python3.11/site-packages/openai/_base_client.py", line 1141, in request
+    raise self._make_status_error_from_response(err.response) from None
+openai.RateLimitError: Error code: 429 - {'error': {'message': 'Provider returned error', 'code': 429, 'metadata': {'raw': 'z-ai/glm-5.2:free is temporarily rate-limited upstream. Please retry shortly, or add your own key to accumulate your rate limits: https://openrouter.ai/settings/integrations', 'provider_name': 'Decart', 'is_byok': False, 'provider_error_code': 'upstream_429', 'limit_source': 'upstream_provider_shared_pool', 'remedy_hint': 'Retry shortly, add your own provider key (https://openrouter.ai/settings/integrations), or route to another provider with provider routing: https://openrouter.ai/docs/features/provider-routing', 'retry_after_seconds': 5, 'retry_after_seconds_raw': 5, 'headers': {'Retry-After': '5'}}}, 'user_id': 'user_3GqihyM3rl5T4H6NLwx0utsYquz'}

--- a/submissions/25620027/week-01/logs/run-03.txt
+++ b/submissions/25620027/week-01/logs/run-03.txt
@@ -1,0 +1,21 @@
+Installed 14 packages in 24ms
+  [model] nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
+  [tool] read_file({'path': 'notes.txt'}) -> Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Task: Report the remaining food expense (pizza budget + drinks - reimbursed)
+and the word, line, and character counts for this entire file.
+
+  [tool] text_stats({'text': 'Meeting memo, 2026-09-01\n\nAttendees: 4\nPizza budget: 48000\nDrinks: 9500\nReimbursed so far: 12000\n\nTask: Report the remaining food expense (pizza budget + drinks - reimbursed)\nand the word, line, and character counts for this entire file.'}) -> {"words": 37, "lines": 9, "characters": 237}
+  [tool] calculator({'expression': '48000 + 9500 - 12000'}) -> 45500
+The text_stats analysis of notes.txt shows:
+- Words: 37
+- Lines: 9
+- Characters: 237
+
+The calculated remaining food expense is:
+48000 (pizza budget) + 9500 (drinks) - 12000 (reimbursed) = **45500**

--- a/submissions/25620027/week-01/logs/run-gemini-01.txt
+++ b/submissions/25620027/week-01/logs/run-gemini-01.txt
@@ -1,0 +1,84 @@
+Installed 14 packages in 40ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_transports/default.py", line 98, in map_httpcore_exceptions
+    yield
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_transports/default.py", line 245, in handle_request
+    resp = self._pool.handle_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 242, in handle_request
+    raise exc from None
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 224, in handle_request
+    response = connection.handle_request(pool_request.request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 94, in handle_request
+    raise exc
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 74, in handle_request
+    stream = self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 117, in _connect
+    stream = self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_backends/sync.py", line 203, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpcore2/_exceptions.py", line 17, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore2.ConnectTimeout: timed out
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_base_client.py", line 1076, in request
+    response = self._send_request(
+               ^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_client.py", line 583, in _send_request
+    response = self._send_with_auth_retry(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_client.py", line 562, in _send_with_auth_retry
+    response = super()._send_request(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_base_client.py", line 999, in _send_request
+    return self._client.send(request, stream=stream, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_client.py", line 980, in send
+    response = self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_client.py", line 1008, in _send_handling_auth
+    response = self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_client.py", line 1043, in _send_handling_redirects
+    response = self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_client.py", line 1076, in _send_single_request
+    response = transport.handle_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_transports/default.py", line 244, in handle_request
+    with map_httpcore_exceptions():
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/httpx2/_transports/default.py", line 115, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx2.ConnectTimeout: timed out
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/0fMHq8ERSjsBC2lu5hxzY/lib/python3.11/site-packages/openai/_base_client.py", line 1094, in request
+    raise APITimeoutError(request=request) from err
+openai.APITimeoutError: Request timed out.

--- a/submissions/25620027/week-01/logs/run-gemini-02.txt
+++ b/submissions/25620027/week-01/logs/run-gemini-02.txt
@@ -1,0 +1,84 @@
+Installed 14 packages in 46ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_transports/default.py", line 98, in map_httpcore_exceptions
+    yield
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_transports/default.py", line 245, in handle_request
+    resp = self._pool.handle_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 242, in handle_request
+    raise exc from None
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 224, in handle_request
+    response = connection.handle_request(pool_request.request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 94, in handle_request
+    raise exc
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 74, in handle_request
+    stream = self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 117, in _connect
+    stream = self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_backends/sync.py", line 203, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpcore2/_exceptions.py", line 17, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore2.ConnectTimeout: timed out
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_base_client.py", line 1076, in request
+    response = self._send_request(
+               ^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_client.py", line 583, in _send_request
+    response = self._send_with_auth_retry(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_client.py", line 562, in _send_with_auth_retry
+    response = super()._send_request(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_base_client.py", line 999, in _send_request
+    return self._client.send(request, stream=stream, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_client.py", line 980, in send
+    response = self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_client.py", line 1008, in _send_handling_auth
+    response = self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_client.py", line 1043, in _send_handling_redirects
+    response = self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_client.py", line 1076, in _send_single_request
+    response = transport.handle_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_transports/default.py", line 244, in handle_request
+    with map_httpcore_exceptions():
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/httpx2/_transports/default.py", line 115, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx2.ConnectTimeout: timed out
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/oXebnLkRo1w4c6nThDun9/lib/python3.11/site-packages/openai/_base_client.py", line 1094, in request
+    raise APITimeoutError(request=request) from err
+openai.APITimeoutError: Request timed out.

--- a/submissions/25620027/week-01/logs/run-gemini-03.txt
+++ b/submissions/25620027/week-01/logs/run-gemini-03.txt
@@ -1,0 +1,84 @@
+Installed 14 packages in 48ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_transports/default.py", line 98, in map_httpcore_exceptions
+    yield
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_transports/default.py", line 245, in handle_request
+    resp = self._pool.handle_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 242, in handle_request
+    raise exc from None
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 224, in handle_request
+    response = connection.handle_request(pool_request.request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 94, in handle_request
+    raise exc
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 74, in handle_request
+    stream = self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 117, in _connect
+    stream = self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_backends/sync.py", line 203, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpcore2/_exceptions.py", line 17, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore2.ConnectError: [Errno 65] No route to host
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_base_client.py", line 1076, in request
+    response = self._send_request(
+               ^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_client.py", line 583, in _send_request
+    response = self._send_with_auth_retry(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_client.py", line 562, in _send_with_auth_retry
+    response = super()._send_request(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_base_client.py", line 999, in _send_request
+    return self._client.send(request, stream=stream, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_client.py", line 980, in send
+    response = self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_client.py", line 1008, in _send_handling_auth
+    response = self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_client.py", line 1043, in _send_handling_redirects
+    response = self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_client.py", line 1076, in _send_single_request
+    response = transport.handle_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_transports/default.py", line 244, in handle_request
+    with map_httpcore_exceptions():
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/httpx2/_transports/default.py", line 115, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx2.ConnectError: [Errno 65] No route to host
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BAD2G_-dFglz7Y07zeAom/lib/python3.11/site-packages/openai/_base_client.py", line 1111, in request
+    raise APIConnectionError(request=request) from err
+openai.APIConnectionError: Connection error.

--- a/submissions/25620027/week-01/logs/run-gemini-04.txt
+++ b/submissions/25620027/week-01/logs/run-gemini-04.txt
@@ -1,0 +1,84 @@
+Installed 14 packages in 40ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_transports/default.py", line 98, in map_httpcore_exceptions
+    yield
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_transports/default.py", line 245, in handle_request
+    resp = self._pool.handle_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 242, in handle_request
+    raise exc from None
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 224, in handle_request
+    response = connection.handle_request(pool_request.request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 94, in handle_request
+    raise exc
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 74, in handle_request
+    stream = self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 117, in _connect
+    stream = self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_backends/sync.py", line 203, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpcore2/_exceptions.py", line 17, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore2.ConnectError: [Errno 65] No route to host
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_base_client.py", line 1076, in request
+    response = self._send_request(
+               ^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_client.py", line 583, in _send_request
+    response = self._send_with_auth_retry(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_client.py", line 562, in _send_with_auth_retry
+    response = super()._send_request(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_base_client.py", line 999, in _send_request
+    return self._client.send(request, stream=stream, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_client.py", line 980, in send
+    response = self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_client.py", line 1008, in _send_handling_auth
+    response = self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_client.py", line 1043, in _send_handling_redirects
+    response = self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_client.py", line 1076, in _send_single_request
+    response = transport.handle_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_transports/default.py", line 244, in handle_request
+    with map_httpcore_exceptions():
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/httpx2/_transports/default.py", line 115, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx2.ConnectError: [Errno 65] No route to host
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/31jiyK7fNNDN2Cq_R1kGG/lib/python3.11/site-packages/openai/_base_client.py", line 1111, in request
+    raise APIConnectionError(request=request) from err
+openai.APIConnectionError: Connection error.

--- a/submissions/25620027/week-01/logs/run-gemini-05.txt
+++ b/submissions/25620027/week-01/logs/run-gemini-05.txt
@@ -1,0 +1,84 @@
+Installed 14 packages in 56ms
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_transports/default.py", line 98, in map_httpcore_exceptions
+    yield
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_transports/default.py", line 245, in handle_request
+    resp = self._pool.handle_request(req)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 242, in handle_request
+    raise exc from None
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_sync/connection_pool.py", line 224, in handle_request
+    response = connection.handle_request(pool_request.request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 94, in handle_request
+    raise exc
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 74, in handle_request
+    stream = self._connect(request)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_sync/connection.py", line 117, in _connect
+    stream = self._network_backend.connect_tcp(**kwargs)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_backends/sync.py", line 203, in connect_tcp
+    with map_exceptions(exc_map):
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpcore2/_exceptions.py", line 17, in map_exceptions
+    raise to_exc(exc) from exc
+httpcore2.ConnectError: [Errno 65] No route to host
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_base_client.py", line 1076, in request
+    response = self._send_request(
+               ^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_client.py", line 583, in _send_request
+    response = self._send_with_auth_retry(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_client.py", line 562, in _send_with_auth_retry
+    response = super()._send_request(request, stream=stream, **kwargs)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_base_client.py", line 999, in _send_request
+    return self._client.send(request, stream=stream, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_client.py", line 980, in send
+    response = self._send_handling_auth(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_client.py", line 1008, in _send_handling_auth
+    response = self._send_handling_redirects(
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_client.py", line 1043, in _send_handling_redirects
+    response = self._send_single_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_client.py", line 1076, in _send_single_request
+    response = transport.handle_request(request)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_transports/default.py", line 244, in handle_request
+    with map_httpcore_exceptions():
+  File "/opt/anaconda3/lib/python3.11/contextlib.py", line 158, in __exit__
+    self.gen.throw(typ, value, traceback)
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/httpx2/_transports/default.py", line 115, in map_httpcore_exceptions
+    raise mapped_exc(message) from exc
+httpx2.ConnectError: [Errno 65] No route to host
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 123, in <module>
+    print(run(goal))
+          ^^^^^^^^^
+  File "/Users/sungjinho/Documents/Obsidian_Raw/jin_icloud2V2_raw/Vscode_Raw/20260529_cleaned_workspace/20_Study_Coursework/ai-agent-engineering-101/submissions/25620027/week-01/first_agent.py", line 99, in run
+    resp = client.chat.completions.create(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_utils/_utils.py", line 298, in wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1296, in create
+    return self._post(
+           ^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_base_client.py", line 1368, in post
+    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/sungjinho/.cache/uv/archive-v0/BTKeg1tlTZbc6OmoC2WHS/lib/python3.11/site-packages/openai/_base_client.py", line 1111, in request
+    raise APIConnectionError(request=request) from err
+openai.APIConnectionError: Connection error.

--- a/submissions/25620027/week-01/logs/run-openai-01.txt
+++ b/submissions/25620027/week-01/logs/run-openai-01.txt
@@ -1,0 +1,25 @@
+Installed 14 packages in 44ms
+  [model] gpt-5-mini-2025-08-07
+  [tool] read_file({'path': 'notes.txt'}) -> Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Task: Report the remaining food expense (pizza budget + drinks - reimbursed)
+and the word, line, and character counts for this entire file.
+
+  [tool] text_stats({'text': 'Meeting memo, 2026-09-01\n\nAttendees: 4\nPizza budget: 48000\nDrinks: 9500\nReimbursed so far: 12000\n\nTask: Report the remaining food expense (pizza budget + drinks - reimbursed)\nand the word, line, and character counts for this entire file.\n'}) -> {"words": 37, "lines": 9, "characters": 238}
+  [tool] calculator({'expression': '48000 + 9500 - 12000'}) -> 45500
+Here are the results you requested.
+
+1) Text statistics for notes.txt
+- Words: 37
+- Lines: 9
+- Characters: 238
+
+2) Expense calculation (pizza budget + drinks - reimbursed)
+- 48,000 + 9,500 - 12,000 = 45,500
+
+If you want the stats broken down by line or a CSV export of the counts, I can provide that.

--- a/submissions/25620027/week-01/notes.txt
+++ b/submissions/25620027/week-01/notes.txt
@@ -1,0 +1,8 @@
+Meeting memo, 2026-09-01
+
+Attendees: 4
+Pizza budget: 48000
+Drinks: 9500
+Reimbursed so far: 12000
+
+Sum the numbers above to get the total the agent should report.

--- a/submissions/25620027/week-01/notes.txt
+++ b/submissions/25620027/week-01/notes.txt
@@ -5,4 +5,5 @@ Pizza budget: 48000
 Drinks: 9500
 Reimbursed so far: 12000
 
-Sum the numbers above to get the total the agent should report.
+Task: Report the remaining food expense (pizza budget + drinks - reimbursed)
+and the word, line, and character counts for this entire file.

--- a/submissions/25620027/week-01/test_calculator.py
+++ b/submissions/25620027/week-01/test_calculator.py
@@ -1,0 +1,19 @@
+import pytest
+
+from first_agent import calculator
+
+
+def test_calculator_keeps_assignment_arithmetic_working() -> None:
+    assert calculator("48000 + 9500 - 12000") == "45500"
+
+
+def test_calculator_rejects_resource_intensive_exponent() -> None:
+    with pytest.raises(ValueError):
+        calculator("2 ** 10000")
+
+
+def test_calculator_rejects_overlong_expression() -> None:
+    expression = "1+" * 50 + "1"
+
+    with pytest.raises(ValueError):
+        calculator(expression)

--- a/submissions/25620027/week-01/test_read_file.py
+++ b/submissions/25620027/week-01/test_read_file.py
@@ -10,12 +10,12 @@ def test_read_file_allows_file_in_working_directory(
     tmp_path: Path, monkeypatch,
 ) -> None:
     # Given
-    note = tmp_path / "note.txt"
+    note = tmp_path / "notes.txt"
     note.write_text("course note", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     # When
-    result = read_file("note.txt")
+    result = read_file("notes.txt")
 
     # Then
     assert result == "course note"
@@ -35,6 +35,36 @@ def test_read_file_denies_same_prefix_sibling(
 
     # When
     result = read_file(str(outside_file))
+
+    # Then
+    assert result == DENIED
+
+
+def test_read_file_denies_environment_file_inside_working_directory(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    # Given
+    environment_file = tmp_path / ".env"
+    environment_file.write_text("placeholder", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    # When
+    result = read_file(environment_file.name)
+
+    # Then
+    assert result == DENIED
+
+
+def test_read_file_denies_unapproved_text_file_inside_working_directory(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    # Given
+    private_note = tmp_path / "private.txt"
+    private_note.write_text("private", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    # When
+    result = read_file(private_note.name)
 
     # Then
     assert result == DENIED

--- a/submissions/25620027/week-01/test_read_file.py
+++ b/submissions/25620027/week-01/test_read_file.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from first_agent import read_file
+
+
+DENIED = "denied: path outside the working directory"
+
+
+def test_read_file_allows_file_in_working_directory(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    # Given
+    note = tmp_path / "note.txt"
+    note.write_text("course note", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    # When
+    result = read_file("note.txt")
+
+    # Then
+    assert result == "course note"
+
+
+def test_read_file_denies_same_prefix_sibling(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    # Given
+    working_directory = tmp_path / "work"
+    sibling_directory = tmp_path / "work-private"
+    working_directory.mkdir()
+    sibling_directory.mkdir()
+    outside_file = sibling_directory / "secret.txt"
+    outside_file.write_text("outside", encoding="utf-8")
+    monkeypatch.chdir(working_directory)
+
+    # When
+    result = read_file(str(outside_file))
+
+    # Then
+    assert result == DENIED
+
+
+def test_read_file_denies_symlink_to_outside_file(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    # Given
+    working_directory = tmp_path / "work"
+    outside_directory = tmp_path / "private"
+    working_directory.mkdir()
+    outside_directory.mkdir()
+    outside_file = outside_directory / "secret.txt"
+    outside_file.write_text("outside", encoding="utf-8")
+    link = working_directory / "linked-secret.txt"
+    link.symlink_to(outside_file)
+    monkeypatch.chdir(working_directory)
+
+    # When
+    result = read_file(link.name)
+
+    # Then
+    assert result == DENIED
+
+
+def test_read_file_denies_regular_outside_path(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    # Given
+    working_directory = tmp_path / "work"
+    outside_file = tmp_path / "secret.txt"
+    working_directory.mkdir()
+    outside_file.write_text("outside", encoding="utf-8")
+    monkeypatch.chdir(working_directory)
+
+    # When
+    result = read_file(str(outside_file))
+
+    # Then
+    assert result == DENIED

--- a/submissions/25620027/week-01/test_text_stats.py
+++ b/submissions/25620027/week-01/test_text_stats.py
@@ -1,0 +1,14 @@
+import json
+
+from first_agent import text_stats
+
+
+def test_text_stats_counts_multiline_text() -> None:
+    # Given
+    text = "alpha beta\nthree"
+
+    # When
+    result = json.loads(text_stats(text))
+
+    # Then
+    assert result == {"words": 3, "lines": 2, "characters": 16}


### PR DESCRIPTION
## What I built

`text_stats`를 세 번째 도구로 추가했습니다. 에이전트가 `notes.txt`를 읽고 단어·줄·문자 수를 집계한 다음, 메모에 적힌 비용을 계산하도록 구성했습니다. 파일 읽기는 과제 입력인 `notes.txt`로 제한했고 계산기에도 입력 크기와 수치 범위 제한을 적용했습니다.

## What I tried and discarded

OpenRouter 무료 모델은 처음 두 번 rate limit으로 실패했습니다. 이후 Nemotron 실행은 완료됐지만 마지막 줄바꿈을 다음 도구에 전달하지 않아 237자로 집계했습니다. Gemini 시도는 timeout 또는 connection error로 실패했고, OpenAI `gpt-5-mini` 실행에서 원본과 같은 37단어·9줄·238문자와 비용 합계 45,500을 확인했습니다. 성공 및 실패 출력은 수정하지 않고 `logs/`와 커밋 이력에 남겼습니다.

## How to run

- API: OpenAI API
- Model: `gpt-5-mini` (successful run: `gpt-5-mini-2025-08-07`)
- Dependency: `openai==3.7.0`

```bash
cd submissions/25620027/week-01
export OPENAI_BASE_URL=https://api.openai.com/v1
export OPENAI_API_KEY=<your OpenAI API key>
export AGENT_MODEL=gpt-5-mini
uv run --isolated --with openai==3.7.0 python first_agent.py
```

## Checklist

- [x] `python scripts/check_week01.py submissions/25620027/week-01` passes locally
- [x] Run logs are committed under `logs/`
- [x] No API keys anywhere in the diff
- [x] History is not squashed
