### PR TITLE
[roster] 26512070

### DIFF
--- a/roster/26512070.md
+++ b/roster/26512070.md
@@ -1,0 +1,4 @@
+# 26512070
+
+- github: gom31
+- name: Gwanwoo Kim


### PR DESCRIPTION
## What I built

Week-01 in-class lab: added my roster entry at `roster/26512070.md` (26512070 / Gwanwoo Kim / @gom31).

## What I tried and discarded

Straightforward first pass — forked, branched off `main` as `roster`, added the single file in the format the roster README specifies. No discarded attempts yet.

## How to run

N/A (roster PR — no code).

## Checklist

- [x] `python scripts/check_pr_paths.py gom31 roster/26512070.md` passes locally (week-01 structural check skipped for roster PRs)
- [x] No API keys anywhere in the diff
- [x] History is not squashed