### PR TITLE
[week-02] 23530007

### DIFF
--- a/submissions/23530007/week-02/REPORT.md
+++ b/submissions/23530007/week-02/REPORT.md
@@ -1,0 +1,42 @@
+# Week 02 — Harness A/B: ReAct vs Plan-then-Execute
+
+- Student ID: 23530007
+- Task: `app.log`에서 ERROR가 가장 많은 시간대를 HH:00 형태로 답하기
+- Success criterion: 최종 답변에 `14:00`이 포함되면 O (기준은 실행 전 `TASK.md`에 커밋)
+- Provider / model: (실행 시 기록)
+- How to run: `export ANTHROPIC_API_KEY=...` 후 `python run_ab.py --runs 3`
+
+## 1. 변형 정의 — 무엇이 같고 무엇이 다른가
+
+독립변수는 하네스 하나다. 모델, 태스크, 도구 집합은 상수로 고정했다. 두 하네스
+(`harness_react.py`, `harness_plan_execute.py`)는 같은 `tools_shared.py`에서
+`Chat`, `Meter`, `TOOLS_IMPL`, `TOOL_SPECS`, `MODEL`을 import하므로 도구 구현과
+스키마, 모델명, 토큰 계측이 모두 동일하다.
+
+강의의 다섯 요소 중 실제로 다르게 잡은 것은 1·3·4이고, 2는 의도적으로 고정,
+5는 두 하네스 모두 비활성이다.
+
+| 요소 | ReAct | Plan-then-Execute | 같음/다름 |
+|---|---|---|---|
+| 1 컨텍스트 관리 | `Chat` 하나. 전체 history를 매 호출에 그대로 전달 | `Chat` 둘. planner(`tools=False`)와 executor를 분리. planner는 태스크·계획·재계획만, executor는 계획 + 단계별 지시와 도구 결과만 본다 | **다름** |
+| 2 도구 granularity | `read_file(path)`, `count_pattern(path, pattern)` | 동일 (같은 모듈 import) | 같음 (통제변수) |
+| 3 종료 조건 | 모델이 도구 호출 없이 답하면 종료, 아니면 `max_steps=8` 상한 | 계획의 단계 수가 실행 횟수를 결정. 단계당 도구 라운드는 `max_tool_rounds=3`, 마지막에 최종 답변 강제 호출 1회. 종료 시점이 모델 판단이 아니라 구조로 정해진다 | **다름** |
+| 4 에러 복구 | 도구 예외를 Observation(`error: ...`)으로 되돌려 다음 스텝에서 모델이 재판단. 매 스텝 방향 전환 가능 | 도구 예외 처리는 공유(동일)하되, 계획 이탈은 `OFF_PLAN` → 재계획 **1회**(`max_replan=1`)로 상한. 추가로 계획 JSON 파싱 실패라는 고유 실패 모드가 있다 | **다름** |
+| 5 개입 지점 | `IRREVERSIBLE = set()` — 비어 있어 승인 절차가 발동하지 않음 | 개입 훅 자체가 없음 | 같음 (둘 다 0) |
+
+요소 5에 대한 단서: 스타터 도구는 `read_file`, `count_pattern` 둘 다 읽기
+전용이라 되돌릴 수 없는 행동이 없다. 따라서 `interventions` 지표는 두 하네스
+모두 구조적으로 0이 되며, 이 지표로는 하네스가 갈리지 않는다. 이 지표를 살리려면
+쓰기/삭제 도구를 양쪽에 똑같이 추가하고 `IRREVERSIBLE`에 등록해야 하는데, 그러면
+도구 집합이 바뀌어 통제변수가 흔들린다. 이번 실험에서는 0으로 고정된 지표로
+보고한다.
+
+## 2. 측정표
+
+<!-- results.csv 6행 이상. 실행 후 채운다. -->
+_실행 대기 중 — API 키가 준비되면 `python run_ab.py --runs 3`로 6회 실행하고 이 표를 `results.csv`에서 채운다._
+
+## 3. 해석
+
+<!-- 어느 요소의 차이가 어느 지표를 움직였는지, logs/의 근거를 들어 한 문단. -->
+_실행 대기 중 — 실측 데이터 없이는 쓰지 않는다._

--- a/submissions/23530007/week-02/REPORT.md
+++ b/submissions/23530007/week-02/REPORT.md
@@ -2,41 +2,91 @@
 
 - Student ID: 23530007
 - Task: `app.log`에서 ERROR가 가장 많은 시간대를 HH:00 형태로 답하기
-- Success criterion: 최종 답변에 `14:00`이 포함되면 O (기준은 실행 전 `TASK.md`에 커밋)
-- Provider / model: (실행 시 기록)
-- How to run: `export ANTHROPIC_API_KEY=...` 후 `python run_ab.py --runs 3`
+- Success criterion: 최종 답변에 `14:00`이 포함되면 O. 기준은 실행 전 커밋(`TASK.md`)에 고정
+- Provider / model: Anthropic Messages API, `claude-opus-5` (`AGENT_MODEL`로 지정), `max_tokens=1024`
+- Tools: `read_file(path)`, `count_pattern(path, pattern)` — 두 하네스가 `tools_shared.py`에서 동일하게 import
+- How to run:
+  ```bash
+  export ANTHROPIC_API_KEY=...          # 커밋 금지, 환경변수로만
+  export AGENT_MODEL=claude-opus-5
+  python run_ab.py --runs 3 --workers 6 # --workers 1 이면 순차, 지표는 동일
+  ```
+
+재현성 관련 두 가지를 미리 밝힌다. 첫째, 스타터 `tools_shared.py`의 기본 모델명
+`claude-sonnet-4-5`는 이 계정의 `models.list()`에 존재하지 않아(날짜가 붙은
+`claude-sonnet-4-5-20250929`만 있다) 그대로 실행하면 404가 난다. 그래서 모델을
+`AGENT_MODEL=claude-opus-5`로 명시했고, 코드는 고치지 않았다. 둘째, `run_ab.py`를
+병렬 실행으로 바꿨다(6회 동시). 각 실행이 자기 `Chat`과 자기 `Meter`를 새로 만들어
+상태를 공유하지 않으므로 네 지표는 동시 실행에 영향받지 않는다. 벽시계로는 362초가
+146초로 줄었다(2.5배). 병렬화는 러너의 성질이고 다섯 요소 중 어느 것도 아니다.
 
 ## 1. 변형 정의 — 무엇이 같고 무엇이 다른가
 
-독립변수는 하네스 하나다. 모델, 태스크, 도구 집합은 상수로 고정했다. 두 하네스
-(`harness_react.py`, `harness_plan_execute.py`)는 같은 `tools_shared.py`에서
-`Chat`, `Meter`, `TOOLS_IMPL`, `TOOL_SPECS`, `MODEL`을 import하므로 도구 구현과
-스키마, 모델명, 토큰 계측이 모두 동일하다.
+독립변수는 하네스 하나다. 모델, 태스크, 도구 집합은 상수로 고정했다. 두 하네스는
+같은 `tools_shared.py`에서 `Chat`, `Meter`, `TOOLS_IMPL`, `TOOL_SPECS`, `MODEL`을
+import하므로 도구 구현·스키마·모델명·토큰 계측이 모두 동일하다.
 
-강의의 다섯 요소 중 실제로 다르게 잡은 것은 1·3·4이고, 2는 의도적으로 고정,
-5는 두 하네스 모두 비활성이다.
+다섯 요소 중 실제로 다르게 잡은 것은 1·3·4이고, 2는 의도적으로 고정, 5는 두 하네스
+모두 비활성이다.
 
 | 요소 | ReAct | Plan-then-Execute | 같음/다름 |
 |---|---|---|---|
-| 1 컨텍스트 관리 | `Chat` 하나. 전체 history를 매 호출에 그대로 전달 | `Chat` 둘. planner(`tools=False`)와 executor를 분리. planner는 태스크·계획·재계획만, executor는 계획 + 단계별 지시와 도구 결과만 본다 | **다름** |
-| 2 도구 granularity | `read_file(path)`, `count_pattern(path, pattern)` | 동일 (같은 모듈 import) | 같음 (통제변수) |
-| 3 종료 조건 | 모델이 도구 호출 없이 답하면 종료, 아니면 `max_steps=8` 상한 | 계획의 단계 수가 실행 횟수를 결정. 단계당 도구 라운드는 `max_tool_rounds=3`, 마지막에 최종 답변 강제 호출 1회. 종료 시점이 모델 판단이 아니라 구조로 정해진다 | **다름** |
-| 4 에러 복구 | 도구 예외를 Observation(`error: ...`)으로 되돌려 다음 스텝에서 모델이 재판단. 매 스텝 방향 전환 가능 | 도구 예외 처리는 공유(동일)하되, 계획 이탈은 `OFF_PLAN` → 재계획 **1회**(`max_replan=1`)로 상한. 추가로 계획 JSON 파싱 실패라는 고유 실패 모드가 있다 | **다름** |
-| 5 개입 지점 | `IRREVERSIBLE = set()` — 비어 있어 승인 절차가 발동하지 않음 | 개입 훅 자체가 없음 | 같음 (둘 다 0) |
+| 1 컨텍스트 관리 | `Chat` 하나. 전체 history를 매 호출에 전달 | `Chat` 둘. planner(`tools=False`)와 executor 분리. executor는 계획을 받고 단계마다 `Execute step i` 지시가 누적된다 | **다름** |
+| 2 도구 granularity | `read_file`, `count_pattern` | 동일 (같은 모듈) | 같음 (통제변수) |
+| 3 종료 조건 | 모델이 도구 호출 없이 답하면 종료, 아니면 `max_steps=8` | 계획의 단계 수가 실행 횟수를 결정. 단계당 도구 라운드 `max_tool_rounds=3`, 마지막에 최종 답변 강제 1회. 종료가 모델 판단이 아니라 구조로 정해진다 | **다름** |
+| 4 에러 복구 | 도구 예외를 Observation으로 되돌려 매 스텝 재판단 | 예외 처리는 공유(동일)하되 계획 이탈은 `OFF_PLAN` → 재계획 1회(`max_replan=1`)로 상한 | **다름** |
+| 5 개입 지점 | `IRREVERSIBLE = set()` — 비어 있어 승인 미발동 | 개입 훅 없음 | 같음 (둘 다 0) |
 
-요소 5에 대한 단서: 스타터 도구는 `read_file`, `count_pattern` 둘 다 읽기
-전용이라 되돌릴 수 없는 행동이 없다. 따라서 `interventions` 지표는 두 하네스
-모두 구조적으로 0이 되며, 이 지표로는 하네스가 갈리지 않는다. 이 지표를 살리려면
-쓰기/삭제 도구를 양쪽에 똑같이 추가하고 `IRREVERSIBLE`에 등록해야 하는데, 그러면
-도구 집합이 바뀌어 통제변수가 흔들린다. 이번 실험에서는 0으로 고정된 지표로
-보고한다.
+요소 5는 스타터 도구가 둘 다 읽기 전용이라 되돌릴 수 없는 행동이 없다. 따라서
+`interventions`는 구조적으로 0이며 이 지표로는 하네스가 갈리지 않는다. 살리려면
+쓰기/삭제 도구를 양쪽에 똑같이 넣고 `IRREVERSIBLE`에 등록해야 하는데 그러면 도구
+집합이 흔들려 통제변수가 깨진다. 이번 실험에서는 0으로 고정된 지표로 보고한다.
 
 ## 2. 측정표
 
-<!-- results.csv 6행 이상. 실행 후 채운다. -->
-_실행 대기 중 — API 키가 준비되면 `python run_ab.py --runs 3`로 6회 실행하고 이 표를 `results.csv`에서 채운다._
+`results.csv` 원본:
+
+| run | harness | success | tokens | iters | interventions | note |
+|---|---|---|---|---|---|---|
+| 1 | react | O | 6,185 | 3 | 0 | |
+| 2 | react | O | 6,333 | 3 | 0 | |
+| 3 | react | O | 6,139 | 3 | 0 | |
+| 4 | plan_exec | O | 81,904 | 15 | 0 | replans=0 |
+| 5 | plan_exec | O | 90,030 | 15 | 0 | replans=0 |
+| 6 | plan_exec | O | 124,542 | 17 | 0 | replans=0 |
+
+집계와 로그에서 센 부수 지표:
+
+| | success | tokens 평균 | tokens 변동폭 | iters 평균 | 도구 호출 | 계획 단계 |
+|---|---|---|---|---|---|---|
+| react | 3/3 | 6,219 | 3% (6,139–6,333) | 3.0 | 5–6회 | — |
+| plan_exec | 3/3 | 98,825 | 43% (81,904–124,542) | 15.7 | 19–44회 | 8 / 7 / 8 |
+
+plan_exec는 react의 **15.9배** 토큰을 썼다. 재계획은 세 번 모두 0회다.
 
 ## 3. 해석
 
-<!-- 어느 요소의 차이가 어느 지표를 움직였는지, logs/의 근거를 들어 한 문단. -->
-_실행 대기 중 — 실측 데이터 없이는 쓰지 않는다._
+이 태스크에서 **성공률은 두 하네스를 가르지 못했다**(3/3 대 3/3). 갈린 것은 토큰과
+반복 횟수이고, 차이는 15.9배와 5.2배로 우연이라 보기 어렵다. 움직인 요소는 **요소 3
+(종료 조건)** 이고, 그것을 증폭한 것이 **요소 1(컨텍스트 관리)** 이다. ReAct는
+`logs/react-01.txt`에서 보듯 파일을 한 번 읽고, 두 번째 스텝에서 `count_pattern`을
+한 턴에 네 개 병렬 호출해 필요한 숫자만 집은 뒤 세 번째 스텝에서 답했다 — 3회 반복,
+도구 5회. 종료 시점을 모델이 직접 골랐기 때문에 "이 정도면 답이 나왔다"는 판단이
+바로 종료로 이어졌다. Plan-then-Execute는 planner가 8단계 계획을 세웠고
+(`"For each hour 00-23..."`, `"verify the totals sum to the overall ERROR line count"`,
+`"noting any tie"` 같은 검증 단계 포함), executor는 그 8단계를 끝까지 걸어갔다.
+`logs/plan_exec-04.txt`를 보면 5단계에서 이미 시간대별 카운트가 나와 14시=6으로 답이
+확정되는데, 6·7·8단계가 그대로 이어져 총합 검증, 동점 확인, 재진술을 수행한다.
+답을 아는 시점과 멈추는 시점이 분리된 것이 반복 횟수 15~17의 직접 원인이다. 여기에
+요소 1이 곱으로 작용한다. executor는 단계마다 누적된 history를 다시 전송하고, 각
+단계의 응답이 마크다운 표를 포함한 장문이어서, 단계가 늘 때 토큰이 선형이 아니라
+초선형으로 불어난다. 주목할 점은 **강의가 예상한 방향이 뒤집혔다**는 것이다.
+Plan-then-Execute가 "토큰이 적게 들고 흐름이 예측 가능"하다는 서술과 달리, 여기서는
+토큰이 15.9배 많았고 변동폭도 43% 대 3%로 훨씬 덜 예측 가능했다. 계획을 미리
+굳히는 것이 절약이 되는 조건은 계획 단계 수가 실제 필요한 작업량에 맞을 때인데,
+단계 분할을 모델이 정하므로 그 수가 통제되지 않는다. 이 태스크는 도구 호출 네다섯
+번이면 끝나는 크기여서, 8단계 계획은 그 자체가 초과 비용이었다. 마지막으로 요소 4의
+유연성 상한(`max_replan=1`)은 이번 실험에서 **한 번도 발동하지 않았다**(replans=0
+×3). 즉 plan_exec의 비용은 재계획 때문이 아니라 과다 계획 때문이며, 이 태스크에서는
+유연성 상한이라는 설계 선택 자체가 지표에 영향을 주지 않았다. 요소 5는 도구가 모두
+읽기 전용이라 양쪽 0으로 묶여 있어 비교에 기여하지 못했다.

--- a/submissions/23530007/week-02/REPORT.md
+++ b/submissions/23530007/week-02/REPORT.md
@@ -29,6 +29,23 @@ import하므로 도구 구현·스키마·모델명·토큰 계측이 모두 동
 다섯 요소 중 실제로 다르게 잡은 것은 1·3·4이고, 2는 의도적으로 고정, 5는 두 하네스
 모두 비활성이다.
 
+```mermaid
+flowchart LR
+  subgraph CONST["상수 · 통제변수"]
+    M["모델<br/>claude-opus-5"]
+    T["태스크<br/>app.log ERROR 최다 시간대"]
+    TL["도구<br/>read_file · count_pattern"]
+  end
+  CONST --> R["ReAct 하네스<br/>3회 실행"]
+  CONST --> P["Plan-then-Execute 하네스<br/>3회 실행"]
+  R --> MET["네 지표<br/>success · tokens · iters · interventions"]
+  P --> MET
+  MET --> V["같은 판정 기준<br/>expected: 14:00"]
+```
+
+FIG. 1 — 독립변수는 하네스 하나. 모델·태스크·도구는 상수로 묶여 있고, 두 하네스는
+같은 판정 기준으로 같은 네 지표를 낸다.
+
 | 요소 | ReAct | Plan-then-Execute | 같음/다름 |
 |---|---|---|---|
 | 1 컨텍스트 관리 | `Chat` 하나. 전체 history를 매 호출에 전달 | `Chat` 둘. planner(`tools=False`)와 executor 분리. executor는 계획을 받고 단계마다 `Execute step i` 지시가 누적된다 | **다름** |
@@ -65,6 +82,30 @@ import하므로 도구 구현·스키마·모델명·토큰 계측이 모두 동
 plan_exec는 react의 **15.9배** 토큰을 썼다. 재계획은 세 번 모두 0회다.
 
 ## 3. 해석
+
+```mermaid
+flowchart TB
+  subgraph A["ReAct · 요소3: 모델이 종료를 결정 → 반복 3.0회, 토큰 6,219"]
+    a0(["태스크"]) --> a1["Thought + Action"]
+    a1 --> a2["Observation"]
+    a2 --> a3{"더 필요한가?"}
+    a3 -- "yes · 매 스텝 재판단" --> a1
+    a3 -- "no · 도구 호출 없이 응답" --> a4(["Answer: 14:00"])
+  end
+  subgraph B["Plan-then-Execute · 요소3: 구조가 종료를 결정 → 반복 15.7회, 토큰 98,825"]
+    b0(["태스크"]) --> b1["PLAN · 1회 호출로 8단계 계획 확정"]
+    b1 --> b2["step 1~4 실행"]
+    b2 --> b3["step 5 · 시간대별 카운트<br/>여기서 이미 14시=6 확정"]
+    b3 --> b4["step 6·7·8 · 총합 검증 · 동점 확인 · 재진술"]
+    b4 --> b5["최종 답변 강제 호출"]
+    b5 --> b6(["Answer: 14:00"])
+  end
+```
+
+FIG. 2 — 답을 아는 시점과 멈추는 시점의 거리. ReAct는 둘이 같은 스텝에서 만나고,
+Plan-then-Execute는 step 5와 step 8로 벌어진다. 이 거리가 반복 횟수의 차이이고,
+누적 history 재전송(요소 1)이 그것을 토큰 차이로 증폭한다.
+
 
 이 태스크에서 **성공률은 두 하네스를 가르지 못했다**(3/3 대 3/3). 갈린 것은 토큰과
 반복 횟수이고, 차이는 15.9배와 5.2배로 우연이라 보기 어렵다. 움직인 요소는 **요소 3

--- a/submissions/23530007/week-02/REPORT.md
+++ b/submissions/23530007/week-02/REPORT.md
@@ -20,6 +20,31 @@
 상태를 공유하지 않으므로 네 지표는 동시 실행에 영향받지 않는다. 벽시계로는 362초가
 146초로 줄었다(2.5배). 병렬화는 러너의 성질이고 다섯 요소 중 어느 것도 아니다.
 
+```mermaid
+flowchart LR
+  subgraph S["starter 원본 · 한 줄도 수정하지 않음"]
+    s1["tools_shared.py"]
+    s2["harness_react.py"]
+    s3["harness_plan_execute.py"]
+    s4["TASK.md"]
+    s5["app.log"]
+  end
+  subgraph W["이번에 작성"]
+    w1["run_ab.py<br/>병렬 실행으로 수정"]
+    w2["REPORT.md<br/>1·2·3부"]
+  end
+  subgraph O["실행 산출물"]
+    o1["results.csv<br/>6행"]
+    o2["logs/ · 6개 파일"]
+  end
+  S --> W --> O
+```
+
+FIG. 1 — 실험 대상인 두 하네스와 공용 도구 모듈은 starter 원본 그대로다. 하네스를
+손대면 다섯 요소의 차이라는 통제가 깨져 A/B가 성립하지 않기 때문이다. 그래서 모델명
+문제도 코드 수정이 아니라 `AGENT_MODEL` 환경변수로 우회했다. 수정한 것은 러너
+(`run_ab.py`)뿐이고, 그것은 다섯 요소 중 어느 것도 아니다.
+
 ## 1. 변형 정의 — 무엇이 같고 무엇이 다른가
 
 독립변수는 하네스 하나다. 모델, 태스크, 도구 집합은 상수로 고정했다. 두 하네스는
@@ -43,7 +68,7 @@ flowchart LR
   MET --> V["같은 판정 기준<br/>expected: 14:00"]
 ```
 
-FIG. 1 — 독립변수는 하네스 하나. 모델·태스크·도구는 상수로 묶여 있고, 두 하네스는
+FIG. 2 — 독립변수는 하네스 하나. 모델·태스크·도구는 상수로 묶여 있고, 두 하네스는
 같은 판정 기준으로 같은 네 지표를 낸다.
 
 | 요소 | ReAct | Plan-then-Execute | 같음/다름 |
@@ -102,7 +127,7 @@ flowchart TB
   end
 ```
 
-FIG. 2 — 답을 아는 시점과 멈추는 시점의 거리. ReAct는 둘이 같은 스텝에서 만나고,
+FIG. 3 — 답을 아는 시점과 멈추는 시점의 거리. ReAct는 둘이 같은 스텝에서 만나고,
 Plan-then-Execute는 step 5와 step 8로 벌어진다. 이 거리가 반복 횟수의 차이이고,
 누적 history 재전송(요소 1)이 그것을 토큰 차이로 증폭한다.
 

--- a/submissions/23530007/week-02/TASK.md
+++ b/submissions/23530007/week-02/TASK.md
@@ -1,0 +1,15 @@
+# Task
+
+The same task for both harnesses. `run_ab.py` reads the `task:` and
+`expected:` lines below. Write the success criterion before you run
+anything, and do not change it after you see the results.
+
+task: In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form.
+
+## Success criterion
+
+A run succeeds when the final answer contains the hour with the most ERROR
+lines in `app.log`, written as HH:00. `app.log` is the reference input; the
+graded runs use it unchanged.
+
+expected: 14:00

--- a/submissions/23530007/week-02/app.log
+++ b/submissions/23530007/week-02/app.log
@@ -1,0 +1,60 @@
+2026-09-01 09:07:27 INFO  job finished in 320ms
+2026-09-01 09:11:56 ERROR NullReference in QuizService.score
+2026-09-01 09:13:14 INFO  health check ok
+2026-09-01 09:26:45 INFO  health check ok
+2026-09-01 09:30:17 INFO  health check ok
+2026-09-01 09:32:05 INFO  request served /api/quiz
+2026-09-01 10:07:50 INFO  session started
+2026-09-01 10:12:15 INFO  request served /api/quiz
+2026-09-01 10:18:22 ERROR db connection refused
+2026-09-01 10:23:48 WARN  retrying upstream call
+2026-09-01 10:53:22 WARN  slow query 1.8s on rooms
+2026-09-01 10:54:07 ERROR NullReference in QuizService.score
+2026-09-01 10:57:10 INFO  cache hit for room 4412
+2026-09-01 11:23:35 ERROR payment webhook signature mismatch
+2026-09-01 11:36:12 INFO  cache hit for room 4412
+2026-09-01 11:39:20 INFO  request served /api/quiz
+2026-09-01 11:40:27 WARN  slow query 1.8s on rooms
+2026-09-01 11:44:02 INFO  health check ok
+2026-09-01 11:56:13 INFO  request served /api/quiz
+2026-09-01 12:08:13 INFO  request served /api/quiz
+2026-09-01 12:28:08 ERROR upstream timeout after 5000ms
+2026-09-01 12:32:19 INFO  health check ok
+2026-09-01 12:49:54 ERROR db connection refused
+2026-09-01 12:50:06 WARN  token near expiry
+2026-09-01 12:53:48 ERROR upstream timeout after 5000ms
+2026-09-01 12:59:50 WARN  token near expiry
+2026-09-01 13:24:27 INFO  cache hit for room 4412
+2026-09-01 13:26:02 INFO  session started
+2026-09-01 13:28:15 INFO  request served /api/quiz
+2026-09-01 13:42:13 ERROR db connection refused
+2026-09-01 13:43:37 WARN  slow query 1.8s on rooms
+2026-09-01 13:59:54 ERROR upstream timeout after 5000ms
+2026-09-01 14:04:06 ERROR NullReference in QuizService.score
+2026-09-01 14:07:11 ERROR NullReference in QuizService.score
+2026-09-01 14:15:56 ERROR upstream timeout after 5000ms
+2026-09-01 14:19:13 INFO  health check ok
+2026-09-01 14:26:19 INFO  request served /api/quiz
+2026-09-01 14:30:20 ERROR db connection refused
+2026-09-01 14:43:37 INFO  job finished in 320ms
+2026-09-01 14:47:03 ERROR upstream timeout after 5000ms
+2026-09-01 14:54:53 ERROR upstream timeout after 5000ms
+2026-09-01 15:04:23 INFO  cache hit for room 4412
+2026-09-01 15:33:16 INFO  request served /api/quiz
+2026-09-01 15:34:38 ERROR payment webhook signature mismatch
+2026-09-01 15:39:25 INFO  cache hit for room 4412
+2026-09-01 15:41:14 ERROR NullReference in QuizService.score
+2026-09-01 15:45:36 INFO  cache hit for room 4412
+2026-09-01 15:48:41 WARN  token near expiry
+2026-09-01 16:11:35 INFO  request served /api/quiz
+2026-09-01 16:16:04 INFO  cache hit for room 4412
+2026-09-01 16:24:31 WARN  slow query 1.8s on rooms
+2026-09-01 16:44:46 INFO  session started
+2026-09-01 16:51:30 WARN  retrying upstream call
+2026-09-01 16:53:34 ERROR NullReference in QuizService.score
+2026-09-01 17:17:14 ERROR NullReference in QuizService.score
+2026-09-01 17:27:48 WARN  token near expiry
+2026-09-01 17:37:46 INFO  health check ok
+2026-09-01 17:48:38 WARN  token near expiry
+2026-09-01 17:55:29 INFO  job finished in 320ms
+2026-09-01 17:56:05 INFO  cache hit for room 4412

--- a/submissions/23530007/week-02/harness_plan_execute.py
+++ b/submissions/23530007/week-02/harness_plan_execute.py
@@ -1,0 +1,98 @@
+"""Week 02 starter — the Plan-then-Execute harness.
+
+One call produces the whole plan as a JSON list. Then each step is executed
+in order with tools. If a step reports OFF_PLAN, the plan is rebuilt once
+(max_replan=1): that number is the flexibility cap, and it is explicit.
+"""
+import json
+import re
+import sys
+
+from tools_shared import Chat, Meter, Reply
+
+SYSTEM_PLAN = (
+    "You are a planner. Reply with a JSON list of short strings, one per step, "
+    "and nothing else. No prose, no code fences."
+)
+SYSTEM_EXEC = (
+    "You execute one step of a plan at a time with the tools you are given. "
+    "If the step cannot be done as planned, reply with a line that starts with "
+    "'OFF_PLAN:' and explain why. When asked for the final answer, reply with a "
+    "line that starts with 'Answer:'."
+)
+
+
+def parse_plan(text: str):
+    """Return a list of step strings, or None if the model did not give JSON."""
+    text = re.sub(r"^```(?:json)?|```$", "", text.strip(), flags=re.M).strip()
+    try:
+        plan = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(plan, list) and all(isinstance(s, str) for s in plan):
+        return plan
+    return None
+
+
+def run_plan_execute(task: str, max_replan: int = 1,
+                     max_tool_rounds: int = 3, log=print):
+    meter = Meter()
+
+    # 1) PLAN: the whole plan in one call, no tools
+    planner = Chat(SYSTEM_PLAN, meter, tools=False)
+    planner.add_user(f"Task: {task}\nAvailable tools: read_file(path), "
+                     f"count_pattern(path, pattern).")
+    raw = planner.send().text
+    plan = parse_plan(raw)
+    if plan is None:                              # a parse failure is one failure mode
+        log(f"[plan] not valid JSON: {raw.strip()[:300]!r}")
+        return "plan parse failed", meter, 0
+    log(f"[plan] {plan}")
+
+    # 2) EXECUTE: each step in order
+    executor = Chat(SYSTEM_EXEC, meter)
+    executor.add_user(f"Task: {task}\nPlan: {json.dumps(plan)}")
+    replans = 0
+    i = 0
+    while i < len(plan):
+        executor.add_user(f"Execute step {i + 1}: {plan[i]}")
+        reply = executor.send()
+        rounds = 0
+        while reply.tool_calls:                   # tool calls inside one step
+            executor.run_tools(reply, log)
+            reply = executor.send()
+            rounds += 1
+            if rounds >= max_tool_rounds and reply.tool_calls:
+                executor.run_tools(reply, log)    # answer every call so the transcript stays valid
+                reply = Reply("OFF_PLAN: step exceeded the tool-call budget", [])
+                break
+        log(f"[step {i + 1}] {reply.text.strip()[:300]}")
+
+        if reply.text.strip().startswith("OFF_PLAN") and replans < max_replan:
+            replans += 1                          # flexibility cap
+            planner.add_user(f"Step {i + 1} ({plan[i]}) failed: {reply.text.strip()[:300]}\n"
+                             f"Reply with a JSON list of the remaining steps.")
+            raw = planner.send().text
+            new_steps = parse_plan(raw)
+            if new_steps is None:
+                log(f"[replan] not valid JSON: {raw.strip()[:300]!r}")
+                break
+            plan = plan[:i] + new_steps
+            log(f"[replan] {plan}")
+            continue
+        i += 1
+
+    executor.add_user("Give the final answer now, starting with 'Answer:'.")
+    final = executor.send()
+    if final.tool_calls:                          # the model tried to keep going
+        executor.run_tools(final, log)
+        final = executor.send()
+    return final.text, meter, replans
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m, replans = run_plan_execute(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions} replans={replans}")

--- a/submissions/23530007/week-02/harness_react.py
+++ b/submissions/23530007/week-02/harness_react.py
@@ -1,0 +1,60 @@
+"""Week 02 starter — the ReAct-style harness.
+
+Every step: the model writes a Thought, calls a tool (Action), sees the result
+(Observation), and decides again. The five axes from the lecture are marked.
+"""
+import sys
+
+from tools_shared import Chat, Meter
+
+SYSTEM = (
+    "You solve tasks with the tools you are given. Before every tool call, "
+    "write one line that starts with 'Thought:' saying what you know and what "
+    "you will do next. When the task is complete, reply with a line that starts "
+    "with 'Answer:' and make no tool call."
+)
+
+# [axis 5] calls that must be approved by a human before they run.
+# The starter tools are read-only, so this set is empty and interventions
+# stay at 0. Add a tool that writes or deletes, and put its name here.
+IRREVERSIBLE = set()
+
+
+def ask_human(call) -> bool:
+    answer = input(f"approve {call.name}({call.args})? [y/N] ").strip().lower()
+    return answer == "y"
+
+
+def run_react(task: str, max_steps: int = 8, log=print):
+    meter = Meter()
+    chat = Chat(SYSTEM, meter)                    # [axis 1] context: full history, every call
+    chat.add_user(task)
+
+    for step in range(max_steps):                 # [axis 3] termination: iteration cap
+        reply = chat.send()
+        if reply.text.strip():
+            log(f"[step {step + 1}] {reply.text.strip()}")
+
+        if not reply.tool_calls:                  # [axis 3] the model chose to finish
+            return reply.text, meter
+
+        approved = []
+        for call in reply.tool_calls:
+            if call.name in IRREVERSIBLE and not ask_human(call):
+                meter.interventions += 1          # [axis 5] intervention point
+                chat.add_tool_result(call, "denied: human did not approve")
+                continue
+            approved.append(call)
+        reply.tool_calls = approved
+        chat.run_tools(reply, log)                # [axis 2] granularity lives in tools_shared
+                                                  # [axis 4] errors come back as Observations
+
+    return "MAX_STEPS reached: incomplete", meter
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m = run_react(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions}")

--- a/submissions/23530007/week-02/logs/plan_exec-04.txt
+++ b/submissions/23530007/week-02/logs/plan_exec-04.txt
@@ -1,0 +1,90 @@
+[plan] ["read_file('app.log') to inspect the log format and locate the timestamp and log-level fields", "Confirm the timestamp pattern (e.g. 'YYYY-MM-DD HH:MM:SS') and the exact ERROR level token used", "Filter to lines containing the ERROR level marker, ignoring lines where 'ERROR' appears only in message text", "Extract the two-digit hour (HH) from each ERROR line's timestamp", "For each hour 00-23, use count_pattern('app.log', <pattern matching that hour plus ERROR>) to get per-hour ERROR counts", 'Tally the counts into an hour-to-count table and verify the totals sum to the overall ERROR line count', 'Identify the hour with the maximum count, noting any tie', 'Report the answer formatted as HH:00']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 1] Step 1 complete. Observations:
+
+- **Format:** `YYYY-MM-DD HH:MM:SS LEVEL  message` — e.g. `2026-09-01 09:11:56 ERROR NullReference in QuizService.score`
+- **Timestamp:** fixed-width, characters 1–19; the hour is at positions 12–13 (two digits, after the space following the date).
+- **Level field:** 
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} (INFO|WARN|ERROR) '}) -> 60
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^'}) -> 60
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} ERROR '}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+[step 2] Step 2 complete. Confirmed:
+
+- **Total lines in file: 60**, and all 60 match `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (INFO|WARN|ERROR) ` — so the timestamp pattern is uniformly `YYYY-MM-DD HH:MM:SS` followed by the level token, with no malformed or continuation lines.
+- The 60-line total equals what `
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} (INFO|WARN) .*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} ERROR .*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '[Ee]rror'}) -> 0
+[step 3] Step 3 complete. Filter validated:
+
+- **0** INFO/WARN lines contain "ERROR" anywhere in the message → no false positives to exclude.
+- **0** ERROR-level lines repeat "ERROR" in the message → no risk of double-counting in a per-line count.
+- **0** lines contain mixed-case `Error`/`error` → the level 
+[step 4] Step 4 complete. Extracted the hour field (positions 12–13) from each of the 19 ERROR lines, in file order:
+
+| # | Timestamp | Hour |
+|---|---|---|
+| 1 | 09:11:56 | **09** |
+| 2 | 10:18:22 | **10** |
+| 3 | 10:54:07 | **10** |
+| 4 | 11:23:35 | **11** |
+| 5 | 12:28:08 | **12** |
+| 6 | 12:49:54 | **12*
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 09:\\d{2}:\\d{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 10:\\d{2}:\\d{2} ERROR '}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 11:\\d{2}:\\d{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 12:\\d{2}:\\d{2} ERROR '}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 13:\\d{2}:\\d{2} ERROR '}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 14:\\d{2}:\\d{2} ERROR '}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 15:\\d{2}:\\d{2} ERROR '}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 16:\\d{2}:\\d{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} 17:\\d{2}:\\d{2} ERROR '}) -> 1
+  [tool] count_pattern({}) -> error: count_pattern() missing 2 required positional arguments: 'path' and 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} (0[0-8]|1[89]|2[0-3]):\\d{2}:\\d{2} ERROR '}) -> 0
+[step 5] Step 5 complete. Per-hour ERROR counts for all 24 hours:
+
+| Hour | ERROR count |
+|---|---|
+| 00–08 | 0 (verified as a block) |
+| 09 | 1 |
+| 10 | 2 |
+| 11 | 1 |
+| 12 | 3 |
+| 13 | 2 |
+| **14** | **6** |
+| 15 | 2 |
+| 16 | 1 |
+| 17 | 1 |
+| 18–23 | 0 (verified as a block) |
+
+The combined inactive ranges 
+[step 6] Step 6 complete. Tally and reconciliation:
+
+| Hour | Count | Running total |
+|---|---|---|
+| 09 | 1 | 1 |
+| 10 | 2 | 3 |
+| 11 | 1 | 4 |
+| 12 | 3 | 7 |
+| 13 | 2 | 9 |
+| 14 | 6 | 15 |
+| 15 | 2 | 17 |
+| 16 | 1 | 18 |
+| 17 | 1 | 19 |
+| 00–08, 18–23 | 0 | 19 |
+
+**Verification — three independent figures 
+[step 7] Step 7 complete. Maximum identification:
+
+- **Maximum: hour 14 with 6 ERROR lines.**
+- Runner-up: hour 12 with 3 — the leader has **double** the next-highest count.
+- **No tie:** 6 occurs exactly once in the distribution; no other hour reaches even 4.
+
+The six contributing lines for hour 14 are:
+- 1
+[step 8] All steps complete. The log contains 60 lines, 19 of them at ERROR level (all on 2026-09-01, spanning hours 09–17). Hour 14 leads with 6 ERROR lines, double the next-highest hour (12, with 3), with no tie.
+
+Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (87.5s)

--- a/submissions/23530007/week-02/logs/plan_exec-05.txt
+++ b/submissions/23530007/week-02/logs/plan_exec-05.txt
@@ -1,0 +1,89 @@
+[plan] ["read_file('app.log') to inspect log line format and confirm timestamp position and ERROR level token", "Determine the timestamp pattern for hours, e.g. lines matching 'HH:MM:SS' with level ERROR", "For each hour 00 through 23, call count_pattern('app.log', <regex matching that hour and ERROR>) to get the ERROR count", "Record each hour's ERROR count in a tally", "Verify total of hourly counts equals count_pattern('app.log', 'ERROR') to catch missed or double-counted lines", 'Select the hour with the maximum count; if tied, note the tie and pick the earliest hour', 'Report the answer formatted as HH:00']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 1] Step 1 complete. Findings:
+
+- **Line format:** `YYYY-MM-DD HH:MM:SS LEVEL  message` (e.g. `2026-09-01 09:11:56 ERROR NullReference in QuizService.score`)
+- **Timestamp position:** date first, then a space, then the time as `HH:MM:SS` at character positions 12–19; the hour is the two digits immediate
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' \\d{2}:\\d{2}:\\d{2} ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} (INFO|WARN|ERROR) '}) -> 60
+[step 2] Step 2 complete. Pattern determined and validated:
+
+- **Total `ERROR` occurrences:** 19
+- **Lines matching ` \d{2}:\d{2}:\d{2} ERROR`:** 19 — identical, so anchoring on the time field captures every ERROR line with no extras (no ERROR appears inside a message body or date).
+- **Well-formed log lines
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 00:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 01:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 02:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 03:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 04:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 05:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 06:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 07:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 08:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 09:\\d{2}:\\d{2} ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 10:\\d{2}:\\d{2} ERROR'}) -> 2
+  [tool] count_pattern({}) -> error: count_pattern() missing 2 required positional arguments: 'path' and 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 11:\\d{2}:\\d{2} ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 12:\\d{2}:\\d{2} ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 13:\\d{2}:\\d{2} ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 14:\\d{2}:\\d{2} ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 15:\\d{2}:\\d{2} ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 16:\\d{2}:\\d{2} ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 17:\\d{2}:\\d{2} ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 18:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 19:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 20:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 21:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({}) -> error: count_pattern() missing 2 required positional arguments: 'path' and 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 22:\\d{2}:\\d{2} ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 23:\\d{2}:\\d{2} ERROR'}) -> 0
+[step 3] Step 3 complete. All 24 hours queried with ` HH:\d{2}:\d{2} ERROR`:
+
+| Hour | ERROR count | | Hour | ERROR count |
+|---|---|---|---|---|
+| 00 | 0 | | 12 | 3 |
+| 01 | 0 | | 13 | 2 |
+| 02 | 0 | | 14 | **6** |
+| 03 | 0 | | 15 | 2 |
+| 04 | 0 | | 16 | 1 |
+| 05 | 0 | | 17 | 1 |
+| 06 | 0 | | 18 | 0 |
+| 07 
+[step 4] Step 4 complete. Tally recorded (non-zero hours only; all other hours are 0):
+
+| Hour | ERROR count |
+|---|---|
+| 09:00 | 1 |
+| 10:00 | 2 |
+| 11:00 | 1 |
+| 12:00 | 3 |
+| 13:00 | 2 |
+| **14:00** | **6** |
+| 15:00 | 2 |
+| 16:00 | 1 |
+| 17:00 | 1 |
+
+- Hours with zero ERRORs: 00–08 and 18–23 (15 hours).
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 1[0-7]:\\d{2}:\\d{2} ERROR'}) -> 18
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 14:\\d{2}:\\d{2} ERROR'}) -> 6
+[step 5] Step 5 complete. Verification passes:
+
+- **Total `ERROR` lines:** 19 — matches the tally sum of **19** exactly, so no lines were missed or double-counted.
+- **Cross-check on hours 10–17** (` 1[0-7]:...ERROR`): 18, which equals the tally for those hours (2+1+3+2+6+2+1+1 = 18). Adding hour 09's 1 give
+[step 6] Step 6 complete. Selecting the maximum from the verified tally:
+
+- **Maximum:** hour **14** with **6** ERROR lines.
+- **Runner-up:** hour 12 with 3 — a clear margin of 3.
+- **Tie check:** no other hour reaches 6, so the tie-breaking rule (earliest hour) is not needed.
+
+Selected hour: **14**, to be f
+[step 7] Step 7 complete. Formatting the selected hour 14 as `HH:00`:
+
+- Hour with the most ERROR lines: **14:00** (6 ERROR lines)
+- Verified: hourly counts sum to 19, matching the total `ERROR` count in the file; no tie at the maximum
+
+Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (91.2s)

--- a/submissions/23530007/week-02/logs/plan_exec-06.txt
+++ b/submissions/23530007/week-02/logs/plan_exec-06.txt
@@ -1,0 +1,105 @@
+[plan] ["read_file('app.log') to inspect log format and confirm timestamp position and ERROR level token", 'Identify the timestamp pattern and extract the two-digit hour field (HH) from each line', 'Filter lines to only those containing the ERROR level marker', "For each hour 00 through 23, use count_pattern('app.log', <regex matching that hour plus ERROR>) to get the ERROR count", "Alternatively verify totals with count_pattern('app.log', 'ERROR') and check the per-hour counts sum to it", 'Compare the 24 counts and select the hour with the highest ERROR count', 'Break any tie by choosing the earliest hour and note the tie in the answer', 'Report the result formatted as HH:00']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 1] Step 1 complete. Findings:
+
+- **Format:** `YYYY-MM-DD HH:MM:SS LEVEL  message` (e.g. `2026-09-01 09:11:56 ERROR NullReference in QuizService.score`)
+- **Timestamp position:** fixed-width at the start of each line; the hour `HH` occupies characters 12–13, i.e. immediately after the date and a space, 
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} '}) -> 60
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 00:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 01:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 02:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 03:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 04:'}) -> 0
+  [tool] count_pattern({'path': 'app.log'}) -> error: count_pattern() missing 1 required positional argument: 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 05:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 06:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 07:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 08:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 09:'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 10:'}) -> 7
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 11:'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 12:'}) -> 7
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 13:'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 14:'}) -> 9
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 15:'}) -> 7
+  [tool] count_pattern({'path': 'app.log'}) -> error: count_pattern() missing 1 required positional argument: 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 16:'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 17:'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 18:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 19:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 20:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 21:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 22:'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 23:'}) -> 0
+[step 2] Step 2 complete. Hour field identified and extracted for every line.
+
+- **Timestamp pattern:** `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ` — matched by **60 lines**, i.e. every line in the file has a well-formed timestamp (no unparsable lines).
+- **Hour field:** the two digits immediately after the date
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} ERROR '}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} (INFO|WARN) '}) -> 41
+[step 3] Step 3 complete. ERROR filter validated.
+
+- Lines containing `ERROR` anywhere: **19**
+- Lines matching the strict level-position regex `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ERROR ` : **19**
+
+The two counts are identical, so `ERROR` only ever appears as the level token — no message text contains the 
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 09:[0-9]{2}:[0-9]{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 10:[0-9]{2}:[0-9]{2} ERROR '}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 11:[0-9]{2}:[0-9]{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 12:[0-9]{2}:[0-9]{2} ERROR '}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 13:[0-9]{2}:[0-9]{2} ERROR '}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 14:[0-9]{2}:[0-9]{2} ERROR '}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 15:[0-9]{2}:[0-9]{2} ERROR '}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 16:[0-9]{2}:[0-9]{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} 17:[0-9]{2}:[0-9]{2} ERROR '}) -> 1
+  [tool] count_pattern({'path': 'app.log'}) -> error: count_pattern() missing 1 required positional argument: 'pattern'
+[step 4] Step 4 complete. Per-hour ERROR counts:
+
+| Hour | ERROR lines |
+|---|---|
+| 00–08 | 0 each (no lines at all in these hours) |
+| 09 | 1 |
+| 10 | 2 |
+| 11 | 1 |
+| 12 | 3 |
+| 13 | 2 |
+| **14** | **6** |
+| 15 | 2 |
+| 16 | 1 |
+| 17 | 1 |
+| 18–23 | 0 each (no lines at all in these hours) |
+
+Sum = 1+2+1+3+
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} (09|10|11|12|13|14|15|16|17):[0-9]{2}:[0-9]{2} ERROR '}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^[0-9-]{10} (00|01|02|03|04|05|06|07|08|18|19|20|21|22|23):[0-9]{2}:[0-9]{2} ERROR '}) -> 0
+[step 5] Step 5 complete. Totals reconcile three ways:
+
+- `count_pattern('app.log', 'ERROR')` → **19**
+- Combined regex for hours 09–17 with ERROR → **19**
+- Combined regex for all other hours (00–08, 18–23) with ERROR → **0**
+- Arithmetic sum of the 24 individual per-hour counts from step 4: 1+2+1+3+2+6+2+1
+[step 6] Step 6 complete. Comparison of all 24 hourly ERROR counts (sorted descending):
+
+| Rank | Hour | ERROR lines |
+|---|---|---|
+| 1 | **14** | **6** |
+| 2 | 12 | 3 |
+| 3= | 10 | 2 |
+| 3= | 13 | 2 |
+| 3= | 15 | 2 |
+| 6= | 09, 11, 16, 17 | 1 each |
+| 10= | 00–08, 18–23 | 0 each |
+
+**Maximum = 6 ERROR line
+[step 7] Step 7 complete — no tie-break was required.
+
+- The maximum ERROR count is **6**, attained by hour **14** alone.
+- The next-highest count is 3 (hour 12); no other hour matches 6, so the maximum is unique.
+- The "earliest hour" tie-break rule therefore did not need to be applied, and there is no tie 
+[step 8] Step 8 complete. Formatting the selected hour (14) in `HH:00` form.
+
+**Summary:** All 60 lines of `app.log` carry a well-formed `YYYY-MM-DD HH:MM:SS LEVEL` timestamp; 19 of them are ERROR lines. Grouped by hour, ERROR counts were 09:1, 10:2, 11:1, 12:3, 13:2, **14:6**, 15:2, 16:1, 17:1 (all other ho
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (145.9s)

--- a/submissions/23530007/week-02/logs/react-01.txt
+++ b/submissions/23530007/week-02/logs/react-01.txt
@@ -1,0 +1,10 @@
+[step 1] Thought: I need to see the log format first.
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Thought: The file may be truncated at 4000 chars; I'll count ERROR lines per hour with regex.
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 18:.*ERROR'}) -> 0
+[step 3] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (12.3s)

--- a/submissions/23530007/week-02/logs/react-02.txt
+++ b/submissions/23530007/week-02/logs/react-02.txt
@@ -1,0 +1,11 @@
+[step 1] Thought: I need to see the log format first.
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Thought: The file may extend beyond 4000 chars; I'll count ERROR lines per hour with regex.
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 14:..:.. ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 12:..:.. ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 1[89]:..:.. ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 2[0-3]:..:.. ERROR'}) -> 0
+[step 3] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (13.1s)

--- a/submissions/23530007/week-02/logs/react-03.txt
+++ b/submissions/23530007/week-02/logs/react-03.txt
@@ -1,0 +1,10 @@
+[step 1] Thought: I need to see the log format first to know how timestamps look.
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Thought: File may be truncated at 4000 chars; count ERROR lines per hour using patterns.
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 14:..:.. ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 12:..:.. ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': ' 15:..:.. ERROR'}) -> 2
+[step 3] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (11.9s)

--- a/submissions/23530007/week-02/results.csv
+++ b/submissions/23530007/week-02/results.csv
@@ -1,0 +1,7 @@
+run,harness,success,tokens,iters,interventions,note
+1,react,O,6185,3,0,
+2,react,O,6333,3,0,
+3,react,O,6139,3,0,
+4,plan_exec,O,81904,15,0,replans=0
+5,plan_exec,O,90030,15,0,replans=0
+6,plan_exec,O,124542,17,0,replans=0

--- a/submissions/23530007/week-02/run_ab.py
+++ b/submissions/23530007/week-02/run_ab.py
@@ -1,0 +1,145 @@
+"""Week 02 — run the A/B experiment and record results.csv.
+
+Usage: python run_ab.py [--runs 3] [--workers 6]
+
+Reads the task and the success criterion from TASK.md, runs each harness
+--runs times, judges every run, appends one line per run to results.csv,
+and saves each run's console output under logs/. Failed runs are kept:
+they are data.
+
+Parallelism is a runner detail, not an experimental variable. Each run builds
+its own Chat and its own Meter, so runs share no state and the four metrics are
+unaffected by how many run at once. --workers 1 reproduces the original
+sequential behaviour exactly. Per-run output is buffered and written to
+logs/<harness>-<nn>.txt after the run finishes, so concurrent runs never
+interleave inside a log file, and rows are written to results.csv in run-number
+order after every run completes.
+"""
+import argparse
+import csv
+import os
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from harness_plan_execute import run_plan_execute
+from harness_react import run_react
+
+HEADER = ["run", "harness", "success", "tokens", "iters", "interventions", "note"]
+
+
+def read_task(path="TASK.md"):
+    text = Path(path).read_text(encoding="utf-8")
+    task = re.search(r"^task:\s*(.+)$", text, flags=re.M)
+    expected = re.search(r"^expected:\s*(.+)$", text, flags=re.M)
+    if not task or not expected:
+        raise SystemExit("TASK.md needs a 'task:' line and an 'expected:' line")
+    return task.group(1).strip(), expected.group(1).strip()
+
+
+def judge(answer: str, expected: str) -> bool:
+    """Success = the expected string appears in the final answer. Fix the
+    criterion in TASK.md before running; do not loosen it afterwards."""
+    return expected.lower() in (answer or "").lower()
+
+
+def one_run(run_no: int, name: str, fn, task: str, expected: str) -> dict:
+    """Execute a single run in isolation and return its row plus its log text.
+
+    Nothing is printed here: the lines are buffered so that runs executing at
+    the same time cannot interleave in a log file or on the console.
+    """
+    lines = []
+
+    def log(msg, _lines=lines):
+        _lines.append(str(msg))
+
+    t0 = time.time()
+    note = ""
+    try:
+        out = fn(task, log=log)
+        answer, meter = out[0], out[1]
+        if name == "plan_exec":
+            note = f"replans={out[2]}"
+    except Exception as e:                # a crash is a failed run, not a lost run
+        answer, meter, note = "", None, f"crash: {type(e).__name__}: {e}"
+        log(note)
+    elapsed = time.time() - t0
+    success = judge(answer, expected)
+    log(f"[final] {answer.strip()[:300]}")
+    log(f"[judge] expected={expected!r} -> {'O' if success else 'X'} ({elapsed:.1f}s)")
+
+    Path("logs", f"{name}-{run_no:02d}.txt").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8")
+
+    return {
+        "run_no": run_no,
+        "name": name,
+        "elapsed": elapsed,
+        "row": [run_no, name, "O" if success else "X",
+                meter.tokens if meter else "",
+                meter.iters if meter else "",
+                meter.interventions if meter else "", note],
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=3,
+                    help="runs per harness (default 3)")
+    ap.add_argument("--workers", type=int, default=6,
+                    help="runs executed concurrently; 1 = sequential (default 6)")
+    args = ap.parse_args()
+
+    task, expected = read_task()
+    Path("logs").mkdir(exist_ok=True)
+    new_file = not Path("results.csv").exists()
+    offset = 0
+    if not new_file:
+        with open("results.csv", encoding="utf-8") as f:
+            offset = sum(1 for _ in f) - 1
+
+    # Run numbers are assigned up front so they do not depend on completion
+    # order: react takes the first block, plan_exec the second, exactly as the
+    # sequential runner numbered them.
+    jobs = []
+    run_no = offset
+    for name, fn in (("react", run_react), ("plan_exec", run_plan_execute)):
+        for _ in range(args.runs):
+            run_no += 1
+            jobs.append((run_no, name, fn))
+
+    workers = max(1, min(args.workers, len(jobs)))
+    print(f"{len(jobs)} run(s), {workers} at a time, model={os.environ.get('AGENT_MODEL', 'default')}")
+
+    wall0 = time.time()
+    if workers == 1:
+        results = [one_run(n, nm, fn, task, expected) for n, nm, fn in jobs]
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(one_run, n, nm, fn, task, expected)
+                       for n, nm, fn in jobs]
+            results = [f.result() for f in futures]
+    wall = time.time() - wall0
+
+    results.sort(key=lambda r: r["run_no"])
+    with open("results.csv", "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new_file:
+            w.writerow(HEADER)
+        for r in results:
+            w.writerow(r["row"])
+
+    for r in results:
+        print(f"  run {r['run_no']:>2} {r['name']:<10} "
+              f"{'O' if r['row'][2] == 'O' else 'X'}  "
+              f"tokens={r['row'][3]:<7} iters={r['row'][4]:<3} "
+              f"{r['elapsed']:.1f}s  {r['row'][6]}")
+    serial = sum(r["elapsed"] for r in results)
+    print(f"\nwall {wall:.1f}s (sum of runs {serial:.1f}s, speedup {serial / wall:.1f}x)")
+    print("results.csv updated;", os.path.abspath("results.csv"))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/23530007/week-02/tools_shared.py
+++ b/submissions/23530007/week-02/tools_shared.py
@@ -1,0 +1,192 @@
+"""Week 02 starter — tools, model call, and meter shared by both harnesses.
+
+Both harnesses import from here. Same tools and same model for both is what
+makes the A/B a harness comparison and not a tool comparison.
+
+Provider is picked from the environment:
+  ANTHROPIC_API_KEY set          -> Anthropic SDK (pip install anthropic)
+  otherwise                      -> OpenAI-compatible (pip install openai)
+                                    OPENAI_API_KEY, optional OPENAI_BASE_URL
+                                    (https://openrouter.ai/api/v1 for OpenRouter)
+  AGENT_MODEL                    optional model override for either provider
+"""
+import json
+import os
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------- tools
+
+
+def read_file(path: str) -> str:
+    """Return the contents of a text file in the working directory."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    with open(full, encoding="utf-8") as f:
+        return f.read()[:4000]          # context guard, same as week 01
+
+
+def count_pattern(path: str, pattern: str) -> str:
+    """Count lines in a text file that match a regular expression."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    rx = re.compile(pattern)
+    with open(full, encoding="utf-8") as f:
+        return str(sum(1 for line in f if rx.search(line)))
+
+
+TOOLS_IMPL = {"read_file": read_file, "count_pattern": count_pattern}
+
+# provider-neutral schemas; Chat converts them per provider
+TOOL_SPECS = [
+    {"name": "read_file",
+     "description": "Read a text file in the working directory (first 4000 characters).",
+     "parameters": {"type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]}},
+    {"name": "count_pattern",
+     "description": "Count the lines of a text file that match a regular expression.",
+     "parameters": {"type": "object",
+                    "properties": {"path": {"type": "string"},
+                                   "pattern": {"type": "string"}},
+                    "required": ["path", "pattern"]}},
+]
+
+# ---------------------------------------------------------------- meter
+
+
+class Meter:
+    """The four metrics of the lab, counted in one place."""
+
+    def __init__(self):
+        self.tokens = 0
+        self.iters = 0            # one iteration = one model call
+        self.interventions = 0    # times a human approved or denied a call
+
+    def add(self, input_tokens: int, output_tokens: int):
+        self.tokens += int(input_tokens or 0) + int(output_tokens or 0)
+        self.iters += 1
+
+
+# ---------------------------------------------------------------- model
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    args: dict
+
+
+@dataclass
+class Reply:
+    text: str
+    tool_calls: list = field(default_factory=list)
+
+
+PROVIDER = "anthropic" if os.environ.get("ANTHROPIC_API_KEY") else "openai"
+MODEL = os.environ.get(
+    "AGENT_MODEL",
+    "claude-sonnet-4-5" if PROVIDER == "anthropic" else "gpt-4o-mini")
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        if PROVIDER == "anthropic":
+            import anthropic
+            _client = anthropic.Anthropic()
+        else:
+            from openai import OpenAI
+            _client = OpenAI()
+    return _client
+
+
+class Chat:
+    """One conversation with the model. Owns the provider-specific message
+    format so the harnesses only see Reply and ToolCall."""
+
+    def __init__(self, system: str, meter: Meter, tools: bool = True):
+        self.system = system
+        self.meter = meter
+        self.tools = tools
+        self.messages = []
+        if PROVIDER == "openai":
+            self.messages.append({"role": "system", "content": system})
+
+    # ---- building the next turn
+    def add_user(self, text: str):
+        self.messages.append({"role": "user", "content": text})
+
+    def add_tool_result(self, call: ToolCall, output: str):
+        if PROVIDER == "anthropic":
+            block = {"type": "tool_result", "tool_use_id": call.id, "content": output}
+            last = self.messages[-1]
+            if last["role"] == "user" and isinstance(last["content"], list):
+                last["content"].append(block)
+            else:
+                self.messages.append({"role": "user", "content": [block]})
+        else:
+            self.messages.append({"role": "tool", "tool_call_id": call.id,
+                                  "content": output})
+
+    # ---- one model call
+    def send(self) -> Reply:
+        if PROVIDER == "anthropic":
+            return self._send_anthropic()
+        return self._send_openai()
+
+    def _send_anthropic(self) -> Reply:
+        kwargs = dict(model=MODEL, max_tokens=1024, system=self.system,
+                      messages=self.messages)
+        if self.tools:
+            kwargs["tools"] = [{"name": t["name"], "description": t["description"],
+                                "input_schema": t["parameters"]} for t in TOOL_SPECS]
+        resp = _get_client().messages.create(**kwargs)
+        self.meter.add(resp.usage.input_tokens, resp.usage.output_tokens)
+        self.messages.append({"role": "assistant", "content": resp.content})
+        text = "".join(b.text for b in resp.content if b.type == "text")
+        calls = [ToolCall(b.id, b.name, dict(b.input))
+                 for b in resp.content if b.type == "tool_use"]
+        return Reply(text, calls)
+
+    def _send_openai(self) -> Reply:
+        kwargs = dict(model=MODEL, messages=self.messages)
+        if self.tools:
+            kwargs["tools"] = [{"type": "function",
+                                "function": {"name": t["name"],
+                                             "description": t["description"],
+                                             "parameters": t["parameters"]}}
+                               for t in TOOL_SPECS]
+        resp = _get_client().chat.completions.create(**kwargs)
+        usage = resp.usage
+        self.meter.add(getattr(usage, "prompt_tokens", 0),
+                       getattr(usage, "completion_tokens", 0))
+        msg = resp.choices[0].message
+        self.messages.append(msg)
+        calls = []
+        for c in msg.tool_calls or []:
+            try:
+                args = json.loads(c.function.arguments or "{}")
+            except json.JSONDecodeError:
+                args = {"_raw": c.function.arguments}
+            calls.append(ToolCall(c.id, c.function.name, args))
+        return Reply(msg.content or "", calls)
+
+    # ---- run the tools a reply asked for, feed results back
+    def run_tools(self, reply: Reply, log=print) -> None:
+        for call in reply.tool_calls:
+            fn = TOOLS_IMPL.get(call.name)
+            if fn is None:
+                out = f"error: unknown tool {call.name}"
+            else:
+                try:
+                    out = str(fn(**call.args))
+                except Exception as e:           # error recovery: the error is an Observation
+                    out = f"error: {e}"
+            log(f"  [tool] {call.name}({call.args}) -> {out[:200].replace(chr(10), ' | ')}")
+            self.add_tool_result(call, out)


### PR DESCRIPTION
## What I built

하네스 A/B 실험. 모델(`claude-opus-5`), 태스크(`app.log`에서 ERROR 최다 시간대 찾기), 도구(`read_file`, `count_pattern`)를 상수로 고정하고 하네스만 독립변수로 바꿔 ReAct형과 Plan-then-Execute형을 각 3회, 총 6회 실행했다. 결과: 성공률은 3/3 대 3/3으로 갈리지 않았고, 토큰이 15.9배(6,219 대 98,825), 반복 횟수가 5.2배(3.0 대 15.7) 갈렸다.

움직인 요소는 3(종료 조건)이고 1(컨텍스트 관리)이 증폭했다. ReAct는 `count_pattern`을 한 턴에 네 개 병렬 호출해 3회 반복으로 끝냈다. Plan-then-Execute는 planner가 8단계 계획을 세우고 executor가 끝까지 걸어갔는데, `logs/plan_exec-04.txt`를 보면 5단계에서 이미 14시=6으로 답이 확정되는데도 6~8단계(총합 검증, 동점 확인, 재진술)가 이어진다. 답을 아는 시점과 멈추는 시점이 분리된 것이 반복 15~17의 원인이고, 단계마다 누적 history를 재전송하면서 토큰이 초선형으로 불어났다.

강의가 예상한 방향이 뒤집혔다. "계획을 미리 굳히므로 토큰이 적게 들고 흐름이 예측 가능"과 달리, 토큰이 15.9배 많았고 변동폭도 43% 대 3%로 더 불안정했다. 단계 분할을 모델이 정하므로 계획 단계 수가 통제되지 않는다는 것이 이유라고 본다.

## What I tried and discarded

**이 PR의 코드와 보고서는 Claude Opus 5와 함께 작성했다.** 커밋 트레일러에 `Co-Authored-By`로 명시해 두었다. 아래는 그 과정에서 실제로 걸린 것들이다.

- **스타터 기본 모델명이 404였다.** `tools_shared.py`의 `claude-sonnet-4-5`는 내 계정 `models.list()`에 없다(날짜가 붙은 `claude-sonnet-4-5-20250929`만 존재). 처음엔 코드를 고치려 했지만, 스타터를 변형하면 다른 사람의 재현과 어긋나므로 `AGENT_MODEL=claude-opus-5` 환경변수로만 지정하고 코드는 그대로 뒀다.
- **실패 실행이 0건이다.** 6회 전부 O가 나왔다. `claude-opus-5`가 이 태스크에 비해 강해서 천장 효과가 났고, 그래서 README가 예시로 든 "Plan-then-Execute가 자기 계획을 파싱 못 해 실패하는" 발견은 이번 실행에 없다. 성공률로는 하네스가 갈리지 않는다는 것 자체가 이번 측정의 결과다. 더 약한 모델로 추가 실행해 실패 모드를 잡는 것이 다음 단계로 남았다.
- **`run_ab.py`를 병렬 실행으로 바꿨다.** 순차로는 362초가 걸렸다. `ThreadPoolExecutor`로 6회를 동시에 돌려 146초로 줄였다(2.5배). 처음엔 그냥 `print`를 두고 병렬화했는데 로그가 뒤섞였다. 실행별로 출력을 버퍼링해 끝난 뒤 파일로 쓰고, `results.csv`는 전부 끝난 뒤 run 번호 순으로 기록하도록 고쳤다. run 번호는 완료 순서가 아니라 미리 배정해서 순차 실행과 같은 번호가 되게 했다. 병렬화는 러너의 성질이고 다섯 요소 중 어느 것도 아니다 — 각 실행이 자기 `Chat`과 자기 `Meter`를 새로 만들어 상태를 공유하지 않으므로 네 지표는 동시 실행에 영향받지 않는다. `--workers 1`이면 원래 순차 동작과 동일하다.
- **실제 모델 호출 전에 스텁으로 배관을 먼저 검증했다.** `Chat.send`를 가짜 응답으로 갈아끼워 `run_ab.py` → `results.csv`/`logs/`, `judge`, 두 하네스 루프가 도는지 확인한 뒤 실제 키를 썼다. 이 스텁은 제출물에 넣지 않았다.
- **정답을 모델과 무관하게 먼저 셌다.** 판정 기준을 실행 후에 고치지 않기 위해, Python으로 `app.log`를 직접 집계해 14시=6건(2위 12시=3건, 동점 없음)을 확인하고 `TASK.md`의 `expected: 14:00`을 **실행 전 커밋**(`f89c8c6`)에 고정했다.
- **로컬 Python이 3.9.6이라 `scripts/check_pr_paths.py`가 안 돌았다.** 그 스크립트가 `str | None` 문법을 써서 3.10+를 요구한다. 제출 코드 자체는 3.9에서 파싱·실행된다. 소유권(`roster/23530007.md`의 `github: yms979` ↔ `submissions/23530007/`)은 수동으로 확인했다.

## How to run

```bash
export ANTHROPIC_API_KEY=...            # 키는 커밋하지 않음, 환경변수로만
export AGENT_MODEL=claude-opus-5        # 스타터 기본값은 이 계정에서 404
cd submissions/23530007/week-02
python run_ab.py --runs 3 --workers 6   # --workers 1 이면 순차, 지표는 동일
```

- Provider/model: Anthropic Messages API, `claude-opus-5`, `max_tokens=1024`
- Tools: `read_file(path)`, `count_pattern(path, pattern)` — 두 하네스가 `tools_shared.py`에서 동일하게 import
- 입력: `app.log` (스타터 원본 그대로)

## Checklist

- [x] `python scripts/check_week02.py submissions/23530007/week-02` passes locally (8/8 ok)
- [x] Run logs are committed under `logs/` (6개, 실행당 1개)
- [x] No API keys anywhere in the diff (히스토리 전체 blob 검사까지 확인)
- [x] History is not squashed (실행 전 커밋과 결과 커밋 2개로 분리)
