### PR TITLE
[week-02] 26510126

### DIFF
--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -191,20 +191,27 @@ Four things about the measurements themselves, before any interpretation:
 
 ## 3. Interpretation
 
-> **TODO — 직접 작성.** 한 문단. 어느 하네스가 어떤 지표로 이겼고 왜인지가
-> 아니라, **어느 요소의 차이가 어느 지표를 움직였는지**를 로그에서 근거를
-> 들어 설명한다. 채점의 절반이 여기다.
->
-> 로그에 남아 있는 근거들:
->
-> - `logs/react-01.txt` — 09시부터 15시까지 한 시간씩 세다 8스텝을 다 쓰고
->   `MAX_STEPS reached`. 14시가 6건이라는 답을 이미 손에 쥔 상태였다.
-> - `logs/react-07.txt` — 파일을 읽고 14시만 한 번 검증하고 3스텝에 종료.
-> - `logs/plan_exec-10.txt` — 계획서 3단계의 `HH:00.*ERROR`를 실행기가 문자
->   그대로 따라 아홉 시간대 전부 0을 받았다. step 1에서 이미 센 값이 컨텍스트에
->   남아 있어 step 4가 그리로 되돌아가 답을 건졌다. 같은 실행에 도구 인자
->   누락 에러가 하나 있고 Observation으로 돌아가 다음 호출에서 교정됐다.
-> - `logs/plan_exec-05.txt` — `max_tool_rounds`와 `max_replan`이 실제로
->   발동한 유일한 실행. 6단계 계획이 5단계로 재작성됐다.
-> - run 10·11·12 모두 `[step 1]`에서 `Answer: 14:00`이 나왔는데 계획의 나머지
->   단계를 끝까지 걷는다.
+The element that moved the numbers is the termination condition. ReAct ends
+when the model stops asking for tools, so the model decides it is finished as
+soon as it holds the answer; Plan-then-Execute ends when the plan list runs
+out, so the number of model calls is fixed by how many steps the planner
+happened to write, and the answer arriving early changes nothing. All three
+Sonnet runs show that directly — `plan_exec-10`, `-11` and `-12` each print
+`Answer: 14:00` at `[step 1]` and then walk the remaining steps anyway,
+finishing at 9, 11 and 12 iterations against ReAct's flat 3. The token gap
+follows from that gap rather than standing on its own: it is the same
+difference compounding, because every extra step is both one more call and
+one more block of history carried into every call after it, which is why
+tokens grew 6.4× while calls grew only 3.7×. Success is where the two
+elements meet instead of acting alone. Both harnesses answered correctly in
+every Sonnet run, and ReAct's single failure — `react-01` on the free model —
+was not caused by its step cap by itself: the harness spent one
+`count_pattern` call per hour because that is the only counting tool it has,
+reached `MAX_STEPS` at the eighth step with 09:00 through 15:00 counted, and
+stopped holding the correct answer of 6 errors at 14:00 without ever
+reporting it. A coarser tool would have fit inside eight steps, and a higher
+cap would have let the fine-grained approach finish; neither the termination
+condition nor the tool granularity produced that failure alone. The same tool
+set cost Plan-then-Execute nothing, because it has no global step cap for a
+long chain of calls to run into — the rigidity that made it expensive is also
+what kept it from failing this way.

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -69,16 +69,30 @@ the answer (`:85`), and one more again if that call still requests tools
 (`:87`). Two inner bounds apply: `max_tool_rounds=3` per step (`:65`) and a
 hard exit if the plan does not parse as a JSON list (`:47`).
 
-### One classification left open
+### Where the replan path belongs
 
 Plan-then-Execute has a second recovery path that ReAct does not: a step
 whose reply starts with `OFF_PLAN` triggers one rebuild of the remaining plan
-(`:71`–`:82`, `max_replan=1`). Whether that belongs under error recovery
-(element 4) or under the termination/flexibility budget (element 3) is a
-judgment call — the lecture defines element 4 in terms of tool exceptions and
-malformed arguments, and `OFF_PLAN` is raised by the model or by the
-tool-round budget, not by a tool throwing. It fired in exactly one of the
-twelve runs (`logs/plan_exec-05.txt`).
+(`harness_plan_execute.py:71`–`:82`, `max_replan=1`). It is counted here
+under the termination condition (element 3), not error recovery (element 4).
+
+The lecture defines element 4 as what the harness does when a tool throws an
+exception or is called with malformed arguments, and that path is the shared
+`try/except` in `Chat.run_tools` described above — identical in both
+harnesses. `OFF_PLAN` is not raised by a tool. It comes either from the model
+declaring the step impossible as planned, or from the harness itself when a
+step exceeds `max_tool_rounds` (`:65`), and its remedy is a counter that caps
+how many times the loop may restructure itself. `max_replan=1` is a bound of
+the same kind as `max_steps=8` and `max_tool_rounds=3`: a limit on how long
+and in what shape the loop is allowed to continue.
+
+Each path fired exactly once in the twelve runs, and in different runs. The
+only genuine tool error is in `logs/plan_exec-10.txt` —
+`count_pattern() missing 1 required positional argument: 'pattern'` — which
+went through `run_tools`, came back as an observation, and was corrected on
+the next call; that is element 4, and ReAct would have handled it the same
+way. The only `OFF_PLAN` is in `logs/plan_exec-05.txt`, where a step ran past
+the tool-round budget and the plan was rebuilt from six steps to five.
 
 ## 2. Measurements
 

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -7,23 +7,78 @@ and were committed before the first run.
 
 ## 1. Variant definition
 
-> **TODO — 직접 작성.** 두 하네스가 무엇이 같고 무엇이 다른지, 다섯 요소
-> (컨텍스트 관리 / 도구 granularity / 종료 조건 / 에러 복구 / 인간 개입 지점)
-> 중 어디를 어떻게 다르게 잡았는지. 아래 두 줄은 코드를 읽으면 바로 확인되는
-> 사실이라 남겨 둔 것이고, 나머지는 채워야 한다.
+Both harnesses run the same task from `TASK.md`, call the same model through
+the same `Chat` wrapper, and import the same two tools from
+`tools_shared.py`. Of the five elements, two are set differently and three
+are held constant.
 
-Held constant across both harnesses:
+### Held constant
 
-- **Tool granularity.** Both import the same `read_file` / `count_pattern`
-  from `tools_shared.py`. The element is a constant here, not a variable.
-- **Human intervention point.** `IRREVERSIBLE` is empty in the ReAct harness
-  and Plan-then-Execute has no approval branch at all, so `interventions` is
-  0 in all twelve runs. On a read-only task this element cannot vary.
+**Tool granularity (element 2).** Both import `read_file` and
+`count_pattern` from `tools_shared.py`; `TOOL_SPECS` is a single module-level
+list neither harness modifies. The file is byte-identical to the starter.
+Counting ERROR lines per hour therefore costs one `count_pattern` call per
+hour in either harness.
 
-> TODO: 나머지 세 요소(컨텍스트 관리, 종료 조건, 에러 복구)를 두 하네스가
-> 각각 어떻게 잡았는지 코드 줄을 인용해 쓴다.
+**Human intervention point (element 5).** `IRREVERSIBLE` is the empty set in
+`harness_react.py:20`, so the approval branch at `:43` is never entered.
+Plan-then-Execute has no approval branch at all. `interventions` is 0 in all
+twelve runs; on a read-only task this element cannot vary.
 
----
+**Tool-level error recovery (element 4).** Every tool call in both harnesses
+goes through `Chat.run_tools` (`tools_shared.py:181`), which wraps the call
+in `try/except` and turns the exception text into the observation:
+
+```python
+except Exception as e:           # error recovery: the error is an Observation
+    out = f"error: {e}"
+```
+
+Neither harness stops on a tool error, and neither sees a different error
+than the other would.
+
+### Set differently
+
+**Context management (element 1).** ReAct keeps one conversation. `Chat` is
+constructed once (`harness_react.py:30`) and every assistant reply and tool
+result is appended to the same message list, so step *n* sees everything from
+steps 1..*n*-1.
+
+Plan-then-Execute keeps two. The `planner` (`harness_plan_execute.py:42`) is
+built with `tools=False`: it sees the task and the tool *names* but never a
+tool result. The `executor` (`:53`) receives the task and the whole plan as
+JSON up front (`:54`), then one `Execute step N` user message per step
+(`:58`), accumulating across every step. On a replan the failure text is
+appended to the **planner's** history (`:73`), not the executor's, so the two
+conversations hold different views of the run from that point on.
+
+Both `Chat` objects share one `Meter`, so `iters` counts model calls across
+the planner and the executor together.
+
+**Termination condition (element 3).** ReAct has two exits: the model returns
+a reply with no tool calls (`harness_react.py:38`), or the loop reaches
+`max_steps=8` (`:33`, falling through to `:52`). The model decides when the
+task is done.
+
+Plan-then-Execute is bounded by the plan instead. The outer loop runs
+`while i < len(plan)` (`harness_plan_execute.py:57`) — the number of
+iterations is fixed by how many steps the planner wrote, and there is no
+early exit: a step that already contains the final answer does not stop the
+loop. After the plan is exhausted the harness forces one more call asking for
+the answer (`:85`), and one more again if that call still requests tools
+(`:87`). Two inner bounds apply: `max_tool_rounds=3` per step (`:65`) and a
+hard exit if the plan does not parse as a JSON list (`:47`).
+
+### One classification left open
+
+Plan-then-Execute has a second recovery path that ReAct does not: a step
+whose reply starts with `OFF_PLAN` triggers one rebuild of the remaining plan
+(`:71`–`:82`, `max_replan=1`). Whether that belongs under error recovery
+(element 4) or under the termination/flexibility budget (element 3) is a
+judgment call — the lecture defines element 4 in terms of tool exceptions and
+malformed arguments, and `OFF_PLAN` is raised by the model or by the
+tool-round budget, not by a tool throwing. It fired in exactly one of the
+twelve runs (`logs/plan_exec-05.txt`).
 
 ## 2. Measurements
 

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -12,6 +12,53 @@ the same `Chat` wrapper, and import the same two tools from
 `tools_shared.py`. Of the five elements, two are set differently and three
 are held constant.
 
+### Structure
+
+```mermaid
+flowchart TB
+  subgraph SH["tools_shared.py — one tool set per experiment, shared by both harnesses"]
+    TS{"AGENT_TOOLSET"}
+    TS -->|fine| FI["read_file + count_pattern<br/>one call per hour to tally"]
+    TS -->|coarse| CO["read_file + count_by_hour<br/>whole tally in one call"]
+    RT["Chat.run_tools — a tool exception<br/>becomes the observation (element 4)"]
+    MT["Meter — tokens, iters, interventions<br/>shared by every Chat in a run"]
+  end
+
+  subgraph RA["harness_react.py — the model decides when it is done"]
+    R1["Chat — one history,<br/>every step sees all earlier ones (element 1)"]
+    R1 --> R2{"step &lt; max_steps = 8 ?<br/>(element 3)"}
+    R2 -->|no| R7(["MAX_STEPS reached: incomplete"])
+    R2 -->|yes| R3["send"]
+    R3 --> R4{"tool calls in the reply ?"}
+    R4 -->|no| R5(["Answer — element 3, model chose to stop"])
+    R4 -->|yes| R6["run_tools"]
+    R6 --> R2
+  end
+
+  subgraph PE["harness_plan_execute.py — the plan decides when it is done"]
+    P1["planner Chat — tools=False,<br/>never sees a tool result (element 1)"]
+    P1 --> P2{"reply parses as a JSON list ?"}
+    P2 -->|no| P3(["plan parse failed"])
+    P2 -->|yes| P4["executor Chat — plan up front,<br/>every step accumulates (element 1)"]
+    P4 --> P5["execute step i"]
+    P5 --> P6{"tool rounds &lt; max_tool_rounds = 3 ?"}
+    P6 -->|exceeded| P7["OFF_PLAN"]
+    P7 --> P9{"replans &lt; max_replan = 1 ?<br/>(element 3)"}
+    P9 -->|yes| P1
+    P9 -->|no| P8
+    P6 -->|ok| P8{"steps remaining ?<br/>no early exit (element 3)"}
+    P8 -->|yes| P5
+    P8 -->|no| P10["forced call: give the final answer"]
+    P10 --> P11(["Answer"])
+  end
+```
+
+The two loops differ in what ends them. ReAct's exit is a property of the
+reply — no tool calls means done — with the step cap as a backstop.
+Plan-then-Execute's exit is a property of the plan: the loop runs once per
+step the planner wrote, and a step that already contains the answer does not
+shorten it.
+
 ### Held constant
 
 **Tool granularity (element 2).** Both import `read_file` and

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -70,7 +70,7 @@ hour in either harness.
 **Human intervention point (element 5).** `IRREVERSIBLE` is the empty set in
 `harness_react.py:20`, so the approval branch at `:43` is never entered.
 Plan-then-Execute has no approval branch at all. `interventions` is 0 in all
-twelve runs; on a read-only task this element cannot vary.
+eighteen runs; on a read-only task this element cannot vary.
 
 **Tool-level error recovery (element 4).** Every tool call in both harnesses
 goes through `Chat.run_tools` (`tools_shared.py:181`), which wraps the call
@@ -133,18 +133,50 @@ how many times the loop may restructure itself. `max_replan=1` is a bound of
 the same kind as `max_steps=8` and `max_tool_rounds=3`: a limit on how long
 and in what shape the loop is allowed to continue.
 
-Each path fired exactly once in the twelve runs, and in different runs. The
-only genuine tool error is in `logs/plan_exec-10.txt` —
+Across the eighteen runs the two paths fired three times between them, never
+in the same run. The only genuine tool error is in `logs/plan_exec-10.txt` —
 `count_pattern() missing 1 required positional argument: 'pattern'` — which
 went through `run_tools`, came back as an observation, and was corrected on
 the next call; that is element 4, and ReAct would have handled it the same
-way. The only `OFF_PLAN` is in `logs/plan_exec-05.txt`, where a step ran past
-the tool-round budget and the plan was rebuilt from six steps to five.
+way. `OFF_PLAN` fired twice, both in Plan-then-Execute and both after a step
+ran past the tool-round budget: `logs/plan_exec-05.txt`, where the plan was
+rebuilt from six steps to five, and `logs/plan_exec-17.txt` in the coarse
+tool set, the only run in that set with `replans=1`.
 
 ## 2. Measurements
 
-Twelve runs, six per model, three per harness per model. Failed runs are
-kept. `interventions` is 0 in every row and is omitted from the tables below.
+Eighteen runs in three sets of six, three per harness in each set. Failed
+runs are kept. `interventions` is 0 in every row and is omitted from the
+tables below.
+
+### Run conditions
+
+Each set holds everything constant but one variable. Set B is the assignment's
+A/B: model, task and tools fixed, harness varied. Set A is the same comparison
+on a free model and is incomplete. Set C repeats set B with one change, the
+tool set, so that tool granularity becomes the variable instead.
+
+| | Set A (1–6) | Set B (7–12) | Set C (13–18) |
+|---|---|---|---|
+| model | `nvidia/nemotron-3.5-lightning:free` | `claude-sonnet-5` | `claude-sonnet-5` |
+| provider | OpenRouter | Anthropic | Anthropic |
+| tool set (`AGENT_TOOLSET`) | `fine` | `fine` | `coarse` |
+| tools | `read_file`, `count_pattern` | same | `read_file`, `count_by_hour` |
+| `max_steps` (ReAct) | 8 | 8 | 8 |
+| `max_tool_rounds` (plan_exec) | 3 | 3 | 3 |
+| `max_replan` (plan_exec) | 1 | 1 | 1 |
+| task | `TASK.md`, unchanged | same | same |
+| success criterion | `TASK.md`, unchanged | same | same |
+
+The three system prompts are unchanged from the starter and live in
+`harness_react.py:10` (`SYSTEM`) and `harness_plan_execute.py:13`
+(`SYSTEM_PLAN`) and `:17` (`SYSTEM_EXEC`). The bounds above are the defaults
+in `run_react` (`harness_react.py:28`) and `run_plan_execute`
+(`harness_plan_execute.py:37`–`:38`); no run overrode them.
+
+The `note` column carries `provider:model` from run 7 and `tools=` from run
+13, the runs after each was added to `run_ab.py`. Earlier rows are covered by
+this table and by the commits that added them.
 
 ### Set A — `nvidia/nemotron-3.5-lightning:free` via OpenRouter
 
@@ -167,6 +199,31 @@ kept. `interventions` is 0 in every row and is omitted from the tables below.
 | 10 | plan_exec | O | 55,054 | 12 | 50.4s | replans=0 |
 | 11 | plan_exec | O | 24,088 | 9 | 22.5s | replans=0 |
 | 12 | plan_exec | O | 34,920 | 11 | 31.2s | replans=0 |
+
+### Set C — `claude-sonnet-5`, coarse tool set
+
+Identical to Set B except that `AGENT_TOOLSET=coarse` swaps `count_pattern`
+for `count_by_hour`, which returns the whole per-hour tally in one call.
+
+| run | harness | success | tokens | iters | wall | note |
+|---:|---|:---:|---:|---:|---:|---|
+| 13 | react | O | 1,688 | 2 | 4.0s | |
+| 14 | react | O | 1,744 | 2 | 3.2s | |
+| 15 | react | O | 1,704 | 2 | 3.1s | |
+| 16 | plan_exec | O | 31,956 | 11 | 28.8s | replans=0 |
+| 17 | plan_exec | O | 41,006 | 14 | 40.4s | replans=1 |
+| 18 | plan_exec | O | 28,841 | 11 | 24.7s | replans=0 |
+
+### Tool granularity, Set B against Set C
+
+Same model, same task, same harnesses; only the tool set differs.
+
+| | ReAct B → C | plan_exec B → C |
+|---|---|---|
+| tokens, median | 5,895 → **1,704** (−71%) | 34,920 → **31,956** (−8%) |
+| iters, median | 3 → 2 | 11 → 11 |
+| wall, median | 6.6s → 3.1s | 31.2s → 28.8s |
+| success | 3/3 → 3/3 | 3/3 → 3/3 |
 
 ### Harness comparison within Set B
 
@@ -194,11 +251,14 @@ both harnesses completed three runs.
 
 ### Cost
 
-Set B consumed 131,972 tokens in total (react 17,910; plan_exec 114,062). At
-the Claude Sonnet 5 rate of $2 / $10 per MTok, and assuming 80–90% of those
-tokens are input — an agent loop resends its history on every call, and no
-prompt caching was used — the set cost roughly **$0.37–$0.48**: about $0.02
-per ReAct run and $0.12 per Plan-then-Execute run.
+Set B consumed 131,972 tokens (react 17,910; plan_exec 114,062) and Set C
+106,939 (react 5,136; plan_exec 101,803). At the Claude Sonnet 5 rate of
+$2 / $10 per MTok, and assuming 80–90% of those tokens are input — an agent
+loop resends its history on every call, and no prompt caching was used — Set
+B cost roughly **$0.37–$0.48** and Set C **$0.30–$0.39**, about $0.67–$0.86
+for the two together. Per run that is roughly $0.02 for ReAct and $0.12 for
+Plan-then-Execute in Set B, falling to under $0.01 and about $0.11 in Set C.
+The coarse tool paid for itself on one harness and not the other.
 
 The estimate is a range rather than a figure because `Meter.add` sums input
 and output into one counter, so the split cannot be recovered from
@@ -220,6 +280,10 @@ env -u ANTHROPIC_API_KEY \
 # Set B
 ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
     python run_ab.py --runs 3
+
+# Set C
+ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
+    AGENT_TOOLSET=coarse python run_ab.py --runs 3
 ```
 
 Python 3.12.14; `openai` 3.6.0 for Set A, `anthropic` 1.4.0 for Set B.
@@ -276,3 +340,17 @@ condition nor the tool granularity produced that failure alone. The same tool
 set cost Plan-then-Execute nothing, because it has no global step cap for a
 long chain of calls to run into — the rigidity that made it expensive is also
 what kept it from failing this way.
+
+Set C tests that last claim directly. Swapping `count_pattern` for
+`count_by_hour` — one call for the whole tally instead of one per hour —
+changes nothing about either harness's code, and the two harnesses respond
+very differently: ReAct's median tokens fall 71% (5,895 to 1,704) and its
+iterations 3 to 2, while Plan-then-Execute's fall 8% (34,920 to 31,956) with
+iterations unchanged at 11. Tool granularity mattered to ReAct because the
+number of calls it makes is determined by what the work needs, so making the
+work cheaper makes the loop shorter. It barely mattered to Plan-then-Execute
+because the number of calls is determined by the length of the plan, which a
+better tool does not shorten: the planner still wrote five or six steps and
+the executor still walked all of them. The same element moved one harness and
+not the other, and which one it moved was decided by the termination
+condition.

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -1,0 +1,155 @@
+# Week 02 — Harness A/B: ReAct vs Plan-then-Execute
+
+Student 26510126. Task, tools and success criterion are fixed in `TASK.md`
+and were committed before the first run.
+
+---
+
+## 1. Variant definition
+
+> **TODO — 직접 작성.** 두 하네스가 무엇이 같고 무엇이 다른지, 다섯 요소
+> (컨텍스트 관리 / 도구 granularity / 종료 조건 / 에러 복구 / 인간 개입 지점)
+> 중 어디를 어떻게 다르게 잡았는지. 아래 두 줄은 코드를 읽으면 바로 확인되는
+> 사실이라 남겨 둔 것이고, 나머지는 채워야 한다.
+
+Held constant across both harnesses:
+
+- **Tool granularity.** Both import the same `read_file` / `count_pattern`
+  from `tools_shared.py`. The element is a constant here, not a variable.
+- **Human intervention point.** `IRREVERSIBLE` is empty in the ReAct harness
+  and Plan-then-Execute has no approval branch at all, so `interventions` is
+  0 in all twelve runs. On a read-only task this element cannot vary.
+
+> TODO: 나머지 세 요소(컨텍스트 관리, 종료 조건, 에러 복구)를 두 하네스가
+> 각각 어떻게 잡았는지 코드 줄을 인용해 쓴다.
+
+---
+
+## 2. Measurements
+
+Twelve runs, six per model, three per harness per model. Failed runs are
+kept. `interventions` is 0 in every row and is omitted from the tables below.
+
+### Set A — `nvidia/nemotron-3.5-lightning:free` via OpenRouter
+
+| run | harness | success | tokens | iters | wall | note |
+|---:|---|:---:|---:|---:|---:|---|
+| 1 | react | X | 22,803 | 8 | 56.3s | MAX_STEPS reached |
+| 2 | react | O | 3,833 | 2 | 43.1s | |
+| 3 | react | O | 3,785 | 2 | 26.4s | |
+| 4 | plan_exec | O | 53,613 | 13 | 395.5s | replans=0 |
+| 5 | plan_exec | X | — | — | 449.1s | 429 free-tier daily cap |
+| 6 | plan_exec | X | — | — | 1.4s | 429 free-tier daily cap |
+
+### Set B — `claude-sonnet-5` via the Anthropic API
+
+| run | harness | success | tokens | iters | wall | note |
+|---:|---|:---:|---:|---:|---:|---|
+| 7 | react | O | 6,154 | 3 | 9.1s | |
+| 8 | react | O | 5,895 | 3 | 6.6s | |
+| 9 | react | O | 5,861 | 3 | 6.6s | |
+| 10 | plan_exec | O | 55,054 | 12 | 50.4s | replans=0 |
+| 11 | plan_exec | O | 24,088 | 9 | 22.5s | replans=0 |
+| 12 | plan_exec | O | 34,920 | 11 | 31.2s | replans=0 |
+
+### Harness comparison within Set B
+
+Set B is the comparable one: the model, the task and the tools are fixed and
+both harnesses completed three runs.
+
+| | react | plan_exec | ratio |
+|---|---:|---:|---:|
+| success | 3/3 | 3/3 | — |
+| tokens, median | 5,895 | 34,920 | 5.9× |
+| tokens, total | 17,910 | 114,062 | 6.4× |
+| iters, median | 3 | 11 | 3.7× |
+| wall, median | 6.6s | 31.2s | 4.7× |
+| tokens, spread | 5,861–6,154 (±2%) | 24,088–55,054 (±44%) | |
+
+### Same harness across models
+
+| harness | metric | Set A (free) | Set B (Sonnet 5) |
+|---|---|---|---|
+| react | success | 2/3 | 3/3 |
+| react | iters | 2, 2, 8 | 3, 3, 3 |
+| react | tokens | 3,785–22,803 | 5,861–6,154 |
+| plan_exec | success | 1/1 measured | 3/3 |
+| plan_exec | iters | 13 | 9, 11, 12 |
+
+### Cost
+
+Set B consumed 131,972 tokens in total (react 17,910; plan_exec 114,062). At
+the Claude Sonnet 5 rate of $2 / $10 per MTok, and assuming 80–90% of those
+tokens are input — an agent loop resends its history on every call, and no
+prompt caching was used — the set cost roughly **$0.37–$0.48**: about $0.02
+per ReAct run and $0.12 per Plan-then-Execute run.
+
+The estimate is a range rather than a figure because `Meter.add` sums input
+and output into one counter, so the split cannot be recovered from
+`results.csv`.
+
+### How to reproduce
+
+```bash
+cp -r weeks/week-02/starter/. submissions/26510126/week-02
+cd submissions/26510126/week-02
+
+# Set A
+env -u ANTHROPIC_API_KEY \
+    OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
+    OPENAI_API_KEY=<openrouter key> \
+    AGENT_MODEL=nvidia/nemotron-3.5-lightning:free \
+    python run_ab.py --runs 3
+
+# Set B
+ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
+    python run_ab.py --runs 3
+```
+
+Python 3.12.14; `openai` 3.6.0 for Set A, `anthropic` 1.4.0 for Set B.
+Console captures are in `logs/`, one file per run, named `<harness>-<run>.txt`.
+
+### Reading the tables
+
+Four things about the measurements themselves, before any interpretation:
+
+1. **Runs 5 and 6 did not fail at the task.** They hit OpenRouter's free-tier
+   daily cap of 50 requests (`X-RateLimit-Remaining: 0`). The cause is the
+   account, not the harness, so Set A cannot be used to compare success rates
+   between the two harnesses. Set B exists for that reason.
+2. **Crashed runs report no metrics.** `run_ab.py` discards the `Meter` when
+   it catches an exception, so runs 5 and 6 have empty token and iteration
+   cells even though run 5 had made roughly eleven model calls before dying.
+   Set A's plan_exec token figure is therefore an undercount of what was
+   actually spent.
+3. **The `note` column carries `provider:model` from run 7 onward.** Rows 1–6
+   predate that change; they were all
+   `nvidia/nemotron-3.5-lightning:free`, recorded in the commit that added them.
+4. **The success criterion checks the last `Answer:` line, not the whole
+   response.** A plain substring match over the full text would score a run O
+   whenever it named 14:00 anywhere while concluding otherwise, and the two
+   harnesses do not end the same way, so that error would not have fallen
+   equally on them. Changed in `run_ab.py` and stated in `TASK.md` before the
+   first run.
+
+---
+
+## 3. Interpretation
+
+> **TODO — 직접 작성.** 한 문단. 어느 하네스가 어떤 지표로 이겼고 왜인지가
+> 아니라, **어느 요소의 차이가 어느 지표를 움직였는지**를 로그에서 근거를
+> 들어 설명한다. 채점의 절반이 여기다.
+>
+> 로그에 남아 있는 근거들:
+>
+> - `logs/react-01.txt` — 09시부터 15시까지 한 시간씩 세다 8스텝을 다 쓰고
+>   `MAX_STEPS reached`. 14시가 6건이라는 답을 이미 손에 쥔 상태였다.
+> - `logs/react-07.txt` — 파일을 읽고 14시만 한 번 검증하고 3스텝에 종료.
+> - `logs/plan_exec-10.txt` — 계획서 3단계의 `HH:00.*ERROR`를 실행기가 문자
+>   그대로 따라 아홉 시간대 전부 0을 받았다. step 1에서 이미 센 값이 컨텍스트에
+>   남아 있어 step 4가 그리로 되돌아가 답을 건졌다. 같은 실행에 도구 인자
+>   누락 에러가 하나 있고 Observation으로 돌아가 다음 호출에서 교정됐다.
+> - `logs/plan_exec-05.txt` — `max_tool_rounds`와 `max_replan`이 실제로
+>   발동한 유일한 실행. 6단계 계획이 5단계로 재작성됐다.
+> - run 10·11·12 모두 `[step 1]`에서 `Answer: 14:00`이 나왔는데 계획의 나머지
+>   단계를 끝까지 걷는다.

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -354,3 +354,73 @@ better tool does not shorten: the planner still wrote five or six steps and
 the executor still walked all of them. The same element moved one harness and
 not the other, and which one it moved was decided by the termination
 condition.
+
+---
+
+## Appendix — a third harness, Plan-then-Execute with an early exit
+
+Sets A, B and C compare two harnesses that were given. This set adds one that
+was not: `harness_plan_execute_early.py`, which differs from
+`harness_plan_execute.py` by a single branch. When a step's reply already
+carries a line beginning with `Answer:`, the run returns there instead of
+walking the rest of the plan and then asking for the answer again. Nothing
+else moves — the same two-Chat context arrangement, the same tools, the same
+shared `run_tools`, still no intervention point, and `parse_plan` imported
+from the original so plan parsing cannot drift.
+
+The point is to separate the two elements that section 3 leans on. Sets A–C
+compare harnesses that differ in *both* termination condition and context
+management, so attributing the token and iteration gap to termination alone
+is inference. Here the context arrangement is identical and only the
+termination branch changes.
+
+Conditions match Set B: `claude-sonnet-5`, `AGENT_TOOLSET=fine`, same task and
+success criterion. Results are in `results_early.csv` and `logs_early/`, kept
+out of `results.csv` because `check_week02.py` counts any harness value other
+than `react|plan_exec` as a malformed row.
+
+| run | success | tokens | iters | wall | plan | exited | skipped | replans |
+|---:|:---:|---:|---:|---:|---|---|---:|---:|
+| 1 | O | 10,666 | 4 | 19.3s | 27 steps | step 1 | 26 | 0 |
+| 2 | O | 876,769 | 103 | 235.8s | 28 → 52 steps | step 50 | 2 | 1 |
+| 3 | O | 8,967 | 4 | 13.8s | 28 steps | step 1 | 27 | 0 |
+
+Against Set B's Plan-then-Execute (median 34,920 tokens, 11 iterations):
+
+| | Set B plan_exec | early exit | |
+|---|---:|---:|---|
+| tokens, median | 34,920 | 10,666 | −69% |
+| iters, median | 11 | 4 | −64% |
+| tokens, worst | 55,054 | 876,769 | 16× worse |
+
+Two of the three runs behave the way the branch was meant to: the model
+volunteers an answer at step 1 and the remaining 26 or 27 steps are dropped,
+bringing the harness to 4 model calls, close to ReAct's 3. That supports
+section 3 — with context management held identical, changing only where the
+loop stops moves iterations and tokens together.
+
+The third run says the branch is not a bound. Its planner wrote 28 steps, the
+pattern those steps used was `HH:00 ERROR`, which matches nothing because the
+timestamps carry real minutes, and every count came back 0. The step that
+noticed raised `OFF_PLAN`, and the replan — the flexibility cap allows one —
+returned **52** steps rather than a shorter list. `max_replan` counts replans,
+not their size, and `plan = plan[:i] + new_steps` splices the new list in
+whole, so a single permitted replan roughly doubled the work. The early exit
+never fired until the model finally wrote an `Answer:` line at step 50, by
+which point the run had made 103 model calls and spent 876,769 tokens.
+
+An early exit that waits for the model to volunteer a keyword is a termination
+condition that depends on the model's phrasing, not a limit the harness
+enforces. Plan-then-Execute's step cap is the plan's own length, and this
+variant does not add one; a `max_steps`-style bound of the kind ReAct has is
+what would have stopped run 2.
+
+Cost: the three runs together came to 896,402 tokens, roughly **$2.51–$3.23**
+at the Claude Sonnet 5 rate — more than Sets B and C combined, with 98% of it
+in run 2 alone.
+
+One instrumentation note: the deciding `Answer:` line in run 2 is not visible
+in `logs_early/plan_exec_early-02.txt`. The runner truncates each step's reply
+to 300 characters when logging, and in that reply the answer falls past the
+cut. `answer_line()` and the judge both read the untruncated text, so the O is
+correct, but the log does not show the evidence for it.

--- a/submissions/26510126/week-02/REPORT.md
+++ b/submissions/26510126/week-02/REPORT.md
@@ -7,10 +7,12 @@ and were committed before the first run.
 
 ## 1. Variant definition
 
-Both harnesses run the same task from `TASK.md`, call the same model through
-the same `Chat` wrapper, and import the same two tools from
-`tools_shared.py`. Of the five elements, two are set differently and three
-are held constant.
+This section describes the two harnesses the assignment compares, as they
+were run in sets A and B: same task from `TASK.md`, same model through the
+same `Chat` wrapper, same two tools from `tools_shared.py`. Of the five
+elements, two are set differently and three are held constant. Set C changes
+one of the constants — the tool set — and the appendix adds a third harness;
+both are noted where they arise.
 
 ### Structure
 
@@ -57,15 +59,18 @@ The two loops differ in what ends them. ReAct's exit is a property of the
 reply — no tool calls means done — with the step cap as a backstop.
 Plan-then-Execute's exit is a property of the plan: the loop runs once per
 step the planner wrote, and a step that already contains the answer does not
-shorten it.
+shorten it. The diagram covers those two harnesses; the third one in the
+appendix is the right-hand loop with one branch added.
 
 ### Held constant
 
-**Tool granularity (element 2).** Both import `read_file` and
-`count_pattern` from `tools_shared.py`; `TOOL_SPECS` is a single module-level
-list neither harness modifies. The file is byte-identical to the starter.
-Counting ERROR lines per hour therefore costs one `count_pattern` call per
-hour in either harness.
+**Tool granularity (element 2).** Both import whatever `tools_shared.py`
+exposes; `TOOL_SPECS` is a single module-level list neither harness modifies,
+so the two always see the same tools. In sets A and B that is `read_file` and
+`count_pattern`, and counting ERROR lines per hour therefore costs one
+`count_pattern` call per hour in either harness. Set C switches the list to
+`read_file` and `count_by_hour` for both harnesses at once, which keeps the
+element constant within each set while making it the variable between them.
 
 **Human intervention point (element 5).** `IRREVERSIBLE` is the empty set in
 `harness_react.py:20`, so the approval branch at `:43` is never entered.
@@ -129,9 +134,10 @@ exception or is called with malformed arguments, and that path is the shared
 harnesses. `OFF_PLAN` is not raised by a tool. It comes either from the model
 declaring the step impossible as planned, or from the harness itself when a
 step exceeds `max_tool_rounds` (`:65`), and its remedy is a counter that caps
-how many times the loop may restructure itself. `max_replan=1` is a bound of
-the same kind as `max_steps=8` and `max_tool_rounds=3`: a limit on how long
-and in what shape the loop is allowed to continue.
+how many times the loop may restructure itself. `max_replan=1` bounds that
+count and nothing else: it does not constrain how long the replacement plan
+may be. The appendix records a run where the one permitted replan returned a
+plan almost twice the length of the original.
 
 Across the eighteen runs the two paths fired three times between them, never
 in the same run. The only genuine tool error is in `logs/plan_exec-10.txt` —
@@ -214,17 +220,6 @@ for `count_by_hour`, which returns the whole per-hour tally in one call.
 | 17 | plan_exec | O | 41,006 | 14 | 40.4s | replans=1 |
 | 18 | plan_exec | O | 28,841 | 11 | 24.7s | replans=0 |
 
-### Tool granularity, Set B against Set C
-
-Same model, same task, same harnesses; only the tool set differs.
-
-| | ReAct B → C | plan_exec B → C |
-|---|---|---|
-| tokens, median | 5,895 → **1,704** (−71%) | 34,920 → **31,956** (−8%) |
-| iters, median | 3 → 2 | 11 → 11 |
-| wall, median | 6.6s → 3.1s | 31.2s → 28.8s |
-| success | 3/3 → 3/3 | 3/3 → 3/3 |
-
 ### Harness comparison within Set B
 
 Set B is the comparable one: the model, the task and the tools are fixed and
@@ -238,6 +233,17 @@ both harnesses completed three runs.
 | iters, median | 3 | 11 | 3.7× |
 | wall, median | 6.6s | 31.2s | 4.7× |
 | tokens, spread | 5,861–6,154 (±2%) | 24,088–55,054 (±44%) | |
+
+### Tool granularity, Set B against Set C
+
+Same model, same task, same harnesses; only the tool set differs.
+
+| | ReAct B → C | plan_exec B → C |
+|---|---|---|
+| tokens, median | 5,895 → **1,704** (−71%) | 34,920 → **31,956** (−8%) |
+| iters, median | 3 → 2 | 11 → 11 |
+| wall, median | 6.6s → 3.1s | 31.2s → 28.8s |
+| success | 3/3 → 3/3 | 3/3 → 3/3 |
 
 ### Same harness across models
 
@@ -284,10 +290,16 @@ ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
 # Set C
 ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
     AGENT_TOOLSET=coarse python run_ab.py --runs 3
+
+# Appendix — the early-exit harness
+ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
+    python run_early.py --runs 3
 ```
 
-Python 3.12.14; `openai` 3.6.0 for Set A, `anthropic` 1.4.0 for Set B.
-Console captures are in `logs/`, one file per run, named `<harness>-<run>.txt`.
+Python 3.12.14; `openai` 3.6.0 for Set A, `anthropic` 1.4.0 for Sets B and C
+and for the appendix. Console captures are one file per run: `logs/` for the
+eighteen runs in `results.csv`, named `<harness>-<run>.txt`, and `logs_early/`
+for the three in `results_early.csv`.
 
 ### Reading the tables
 
@@ -302,9 +314,10 @@ Four things about the measurements themselves, before any interpretation:
    cells even though run 5 had made roughly eleven model calls before dying.
    Set A's plan_exec token figure is therefore an undercount of what was
    actually spent.
-3. **The `note` column carries `provider:model` from run 7 onward.** Rows 1–6
-   predate that change; they were all
-   `nvidia/nemotron-3.5-lightning:free`, recorded in the commit that added them.
+3. **The `note` column was filled in gradually.** `provider:model` appears
+   from run 7 and `tools=` from run 13, each starting with the runs after it
+   was added to `run_ab.py`. Rows before those points are covered by the run
+   conditions table above and by the commits that produced them.
 4. **The success criterion checks the last `Answer:` line, not the whole
    response.** A plain substring match over the full text would score a run O
    whenever it named 14:00 anywhere while concluding otherwise, and the two
@@ -350,8 +363,8 @@ iterations unchanged at 11. Tool granularity mattered to ReAct because the
 number of calls it makes is determined by what the work needs, so making the
 work cheaper makes the loop shorter. It barely mattered to Plan-then-Execute
 because the number of calls is determined by the length of the plan, which a
-better tool does not shorten: the planner still wrote five or six steps and
-the executor still walked all of them. The same element moved one harness and
+better tool does not shorten: the planner wrote six steps in each of the three
+Set C runs, as it had in Set B, and the executor still walked all of them. The same element moved one harness and
 not the other, and which one it moved was decided by the termination
 condition.
 
@@ -392,6 +405,18 @@ Against Set B's Plan-then-Execute (median 34,920 tokens, 11 iterations):
 | tokens, median | 34,920 | 10,666 | −69% |
 | iters, median | 11 | 4 | −64% |
 | tokens, worst | 55,054 | 876,769 | 16× worse |
+
+The planner's output length is not stable between the two groups. Counting
+the steps in every plan logged: the nine Plan-then-Execute runs in sets A, B
+and C produced plans of five or six steps, while the three early-exit runs
+produced 27, 28 and 28. The planner's system prompt, its first user message,
+the model and the tool set are identical across both groups — `SYSTEM_PLAN`
+and the `planner.add_user` string are byte-identical between
+`harness_plan_execute.py` and `harness_plan_execute_early.py`, both groups ran
+`claude-sonnet-5`, and `results_early.csv` records `tools=fine`. The
+difference is in what the model returned, not in the harness. The medians
+below are therefore compared across plans of unequal length: the Set B runs
+walked five or six steps, and the early-exit runs skipped 26 or 27.
 
 Two of the three runs behave the way the branch was meant to: the model
 volunteers an answer at step 1 and the remaining 26 or 27 steps are dropped,

--- a/submissions/26510126/week-02/TASK.md
+++ b/submissions/26510126/week-02/TASK.md
@@ -8,8 +8,14 @@ task: In app.log, which hour (HH:00) has the most ERROR lines? Answer with the h
 
 ## Success criterion
 
-A run succeeds when the final answer contains the hour with the most ERROR
-lines in `app.log`, written as HH:00. `app.log` is the reference input; the
-graded runs use it unchanged.
+A run succeeds when the last line beginning with `Answer:` in the harness's
+final response contains the hour with the most ERROR lines in `app.log`,
+written as HH:00. If the response contains no `Answer:` line, the whole
+response is checked instead. `app.log` is the reference input; the graded
+runs use it unchanged.
+
+This criterion was fixed before the first run. It is narrower than a
+substring match over the whole response, which would score a run O whenever
+it named the expected hour anywhere while concluding otherwise.
 
 expected: 14:00

--- a/submissions/26510126/week-02/TASK.md
+++ b/submissions/26510126/week-02/TASK.md
@@ -1,0 +1,15 @@
+# Task
+
+The same task for both harnesses. `run_ab.py` reads the `task:` and
+`expected:` lines below. Write the success criterion before you run
+anything, and do not change it after you see the results.
+
+task: In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form.
+
+## Success criterion
+
+A run succeeds when the final answer contains the hour with the most ERROR
+lines in `app.log`, written as HH:00. `app.log` is the reference input; the
+graded runs use it unchanged.
+
+expected: 14:00

--- a/submissions/26510126/week-02/app.log
+++ b/submissions/26510126/week-02/app.log
@@ -1,0 +1,60 @@
+2026-09-01 09:07:27 INFO  job finished in 320ms
+2026-09-01 09:11:56 ERROR NullReference in QuizService.score
+2026-09-01 09:13:14 INFO  health check ok
+2026-09-01 09:26:45 INFO  health check ok
+2026-09-01 09:30:17 INFO  health check ok
+2026-09-01 09:32:05 INFO  request served /api/quiz
+2026-09-01 10:07:50 INFO  session started
+2026-09-01 10:12:15 INFO  request served /api/quiz
+2026-09-01 10:18:22 ERROR db connection refused
+2026-09-01 10:23:48 WARN  retrying upstream call
+2026-09-01 10:53:22 WARN  slow query 1.8s on rooms
+2026-09-01 10:54:07 ERROR NullReference in QuizService.score
+2026-09-01 10:57:10 INFO  cache hit for room 4412
+2026-09-01 11:23:35 ERROR payment webhook signature mismatch
+2026-09-01 11:36:12 INFO  cache hit for room 4412
+2026-09-01 11:39:20 INFO  request served /api/quiz
+2026-09-01 11:40:27 WARN  slow query 1.8s on rooms
+2026-09-01 11:44:02 INFO  health check ok
+2026-09-01 11:56:13 INFO  request served /api/quiz
+2026-09-01 12:08:13 INFO  request served /api/quiz
+2026-09-01 12:28:08 ERROR upstream timeout after 5000ms
+2026-09-01 12:32:19 INFO  health check ok
+2026-09-01 12:49:54 ERROR db connection refused
+2026-09-01 12:50:06 WARN  token near expiry
+2026-09-01 12:53:48 ERROR upstream timeout after 5000ms
+2026-09-01 12:59:50 WARN  token near expiry
+2026-09-01 13:24:27 INFO  cache hit for room 4412
+2026-09-01 13:26:02 INFO  session started
+2026-09-01 13:28:15 INFO  request served /api/quiz
+2026-09-01 13:42:13 ERROR db connection refused
+2026-09-01 13:43:37 WARN  slow query 1.8s on rooms
+2026-09-01 13:59:54 ERROR upstream timeout after 5000ms
+2026-09-01 14:04:06 ERROR NullReference in QuizService.score
+2026-09-01 14:07:11 ERROR NullReference in QuizService.score
+2026-09-01 14:15:56 ERROR upstream timeout after 5000ms
+2026-09-01 14:19:13 INFO  health check ok
+2026-09-01 14:26:19 INFO  request served /api/quiz
+2026-09-01 14:30:20 ERROR db connection refused
+2026-09-01 14:43:37 INFO  job finished in 320ms
+2026-09-01 14:47:03 ERROR upstream timeout after 5000ms
+2026-09-01 14:54:53 ERROR upstream timeout after 5000ms
+2026-09-01 15:04:23 INFO  cache hit for room 4412
+2026-09-01 15:33:16 INFO  request served /api/quiz
+2026-09-01 15:34:38 ERROR payment webhook signature mismatch
+2026-09-01 15:39:25 INFO  cache hit for room 4412
+2026-09-01 15:41:14 ERROR NullReference in QuizService.score
+2026-09-01 15:45:36 INFO  cache hit for room 4412
+2026-09-01 15:48:41 WARN  token near expiry
+2026-09-01 16:11:35 INFO  request served /api/quiz
+2026-09-01 16:16:04 INFO  cache hit for room 4412
+2026-09-01 16:24:31 WARN  slow query 1.8s on rooms
+2026-09-01 16:44:46 INFO  session started
+2026-09-01 16:51:30 WARN  retrying upstream call
+2026-09-01 16:53:34 ERROR NullReference in QuizService.score
+2026-09-01 17:17:14 ERROR NullReference in QuizService.score
+2026-09-01 17:27:48 WARN  token near expiry
+2026-09-01 17:37:46 INFO  health check ok
+2026-09-01 17:48:38 WARN  token near expiry
+2026-09-01 17:55:29 INFO  job finished in 320ms
+2026-09-01 17:56:05 INFO  cache hit for room 4412

--- a/submissions/26510126/week-02/harness_plan_execute.py
+++ b/submissions/26510126/week-02/harness_plan_execute.py
@@ -1,0 +1,98 @@
+"""Week 02 starter — the Plan-then-Execute harness.
+
+One call produces the whole plan as a JSON list. Then each step is executed
+in order with tools. If a step reports OFF_PLAN, the plan is rebuilt once
+(max_replan=1): that number is the flexibility cap, and it is explicit.
+"""
+import json
+import re
+import sys
+
+from tools_shared import Chat, Meter, Reply
+
+SYSTEM_PLAN = (
+    "You are a planner. Reply with a JSON list of short strings, one per step, "
+    "and nothing else. No prose, no code fences."
+)
+SYSTEM_EXEC = (
+    "You execute one step of a plan at a time with the tools you are given. "
+    "If the step cannot be done as planned, reply with a line that starts with "
+    "'OFF_PLAN:' and explain why. When asked for the final answer, reply with a "
+    "line that starts with 'Answer:'."
+)
+
+
+def parse_plan(text: str):
+    """Return a list of step strings, or None if the model did not give JSON."""
+    text = re.sub(r"^```(?:json)?|```$", "", text.strip(), flags=re.M).strip()
+    try:
+        plan = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(plan, list) and all(isinstance(s, str) for s in plan):
+        return plan
+    return None
+
+
+def run_plan_execute(task: str, max_replan: int = 1,
+                     max_tool_rounds: int = 3, log=print):
+    meter = Meter()
+
+    # 1) PLAN: the whole plan in one call, no tools
+    planner = Chat(SYSTEM_PLAN, meter, tools=False)
+    planner.add_user(f"Task: {task}\nAvailable tools: read_file(path), "
+                     f"count_pattern(path, pattern).")
+    raw = planner.send().text
+    plan = parse_plan(raw)
+    if plan is None:                              # a parse failure is one failure mode
+        log(f"[plan] not valid JSON: {raw.strip()[:300]!r}")
+        return "plan parse failed", meter, 0
+    log(f"[plan] {plan}")
+
+    # 2) EXECUTE: each step in order
+    executor = Chat(SYSTEM_EXEC, meter)
+    executor.add_user(f"Task: {task}\nPlan: {json.dumps(plan)}")
+    replans = 0
+    i = 0
+    while i < len(plan):
+        executor.add_user(f"Execute step {i + 1}: {plan[i]}")
+        reply = executor.send()
+        rounds = 0
+        while reply.tool_calls:                   # tool calls inside one step
+            executor.run_tools(reply, log)
+            reply = executor.send()
+            rounds += 1
+            if rounds >= max_tool_rounds and reply.tool_calls:
+                executor.run_tools(reply, log)    # answer every call so the transcript stays valid
+                reply = Reply("OFF_PLAN: step exceeded the tool-call budget", [])
+                break
+        log(f"[step {i + 1}] {reply.text.strip()[:300]}")
+
+        if reply.text.strip().startswith("OFF_PLAN") and replans < max_replan:
+            replans += 1                          # flexibility cap
+            planner.add_user(f"Step {i + 1} ({plan[i]}) failed: {reply.text.strip()[:300]}\n"
+                             f"Reply with a JSON list of the remaining steps.")
+            raw = planner.send().text
+            new_steps = parse_plan(raw)
+            if new_steps is None:
+                log(f"[replan] not valid JSON: {raw.strip()[:300]!r}")
+                break
+            plan = plan[:i] + new_steps
+            log(f"[replan] {plan}")
+            continue
+        i += 1
+
+    executor.add_user("Give the final answer now, starting with 'Answer:'.")
+    final = executor.send()
+    if final.tool_calls:                          # the model tried to keep going
+        executor.run_tools(final, log)
+        final = executor.send()
+    return final.text, meter, replans
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m, replans = run_plan_execute(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions} replans={replans}")

--- a/submissions/26510126/week-02/harness_plan_execute_early.py
+++ b/submissions/26510126/week-02/harness_plan_execute_early.py
@@ -1,0 +1,107 @@
+"""Week 02 extension — Plan-then-Execute with an early exit.
+
+Identical to `harness_plan_execute.py` except for one branch: when a step's
+reply already carries a line starting with 'Answer:', the loop returns there
+instead of walking the rest of the plan and then asking for the answer again.
+
+Only element 3 (termination condition) changes. Context management is the
+same two-Chat arrangement, the tools are whatever `tools_shared` exposes,
+error recovery is the same shared `run_tools`, and there is still no
+intervention point. `parse_plan` is imported from the original module rather
+than copied, so the plan-parsing behaviour cannot drift between the two.
+"""
+import json
+import sys
+
+from harness_plan_execute import parse_plan
+from tools_shared import Chat, Meter, Reply
+
+SYSTEM_PLAN = (
+    "You are a planner. Reply with a JSON list of short strings, one per step, "
+    "and nothing else. No prose, no code fences."
+)
+SYSTEM_EXEC = (
+    "You execute one step of a plan at a time with the tools you are given. "
+    "If the step cannot be done as planned, reply with a line that starts with "
+    "'OFF_PLAN:' and explain why. When asked for the final answer, reply with a "
+    "line that starts with 'Answer:'."
+)
+
+
+def answer_line(text: str):
+    """The first line that starts with 'Answer:', or None."""
+    for line in (text or "").splitlines():
+        if line.strip().lower().startswith("answer:"):
+            return line.strip()
+    return None
+
+
+def run_plan_execute_early(task: str, max_replan: int = 1,
+                           max_tool_rounds: int = 3, log=print):
+    meter = Meter()
+
+    planner = Chat(SYSTEM_PLAN, meter, tools=False)
+    planner.add_user(f"Task: {task}\nAvailable tools: read_file(path), "
+                     f"count_pattern(path, pattern).")
+    raw = planner.send().text
+    plan = parse_plan(raw)
+    if plan is None:
+        log(f"[plan] not valid JSON: {raw.strip()[:300]!r}")
+        return "plan parse failed", meter, 0
+    log(f"[plan] {plan}")
+
+    executor = Chat(SYSTEM_EXEC, meter)
+    executor.add_user(f"Task: {task}\nPlan: {json.dumps(plan)}")
+    replans = 0
+    i = 0
+    while i < len(plan):
+        executor.add_user(f"Execute step {i + 1}: {plan[i]}")
+        reply = executor.send()
+        rounds = 0
+        while reply.tool_calls:
+            executor.run_tools(reply, log)
+            reply = executor.send()
+            rounds += 1
+            if rounds >= max_tool_rounds and reply.tool_calls:
+                executor.run_tools(reply, log)
+                reply = Reply("OFF_PLAN: step exceeded the tool-call budget", [])
+                break
+        log(f"[step {i + 1}] {reply.text.strip()[:300]}")
+
+        # --- the only difference from harness_plan_execute.py ---
+        early = answer_line(reply.text)
+        if early:
+            skipped = len(plan) - (i + 1)
+            log(f"[early exit] answered at step {i + 1}; {skipped} step(s) "
+                f"skipped, no final call")
+            return reply.text, meter, replans
+        # --------------------------------------------------------
+
+        if reply.text.strip().startswith("OFF_PLAN") and replans < max_replan:
+            replans += 1
+            planner.add_user(f"Step {i + 1} ({plan[i]}) failed: {reply.text.strip()[:300]}\n"
+                             f"Reply with a JSON list of the remaining steps.")
+            raw = planner.send().text
+            new_steps = parse_plan(raw)
+            if new_steps is None:
+                log(f"[replan] not valid JSON: {raw.strip()[:300]!r}")
+                break
+            plan = plan[:i] + new_steps
+            log(f"[replan] {plan}")
+            continue
+        i += 1
+
+    executor.add_user("Give the final answer now, starting with 'Answer:'.")
+    final = executor.send()
+    if final.tool_calls:
+        executor.run_tools(final, log)
+        final = executor.send()
+    return final.text, meter, replans
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m, replans = run_plan_execute_early(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions} replans={replans}")

--- a/submissions/26510126/week-02/harness_react.py
+++ b/submissions/26510126/week-02/harness_react.py
@@ -1,0 +1,60 @@
+"""Week 02 starter — the ReAct-style harness.
+
+Every step: the model writes a Thought, calls a tool (Action), sees the result
+(Observation), and decides again. The five axes from the lecture are marked.
+"""
+import sys
+
+from tools_shared import Chat, Meter
+
+SYSTEM = (
+    "You solve tasks with the tools you are given. Before every tool call, "
+    "write one line that starts with 'Thought:' saying what you know and what "
+    "you will do next. When the task is complete, reply with a line that starts "
+    "with 'Answer:' and make no tool call."
+)
+
+# [axis 5] calls that must be approved by a human before they run.
+# The starter tools are read-only, so this set is empty and interventions
+# stay at 0. Add a tool that writes or deletes, and put its name here.
+IRREVERSIBLE = set()
+
+
+def ask_human(call) -> bool:
+    answer = input(f"approve {call.name}({call.args})? [y/N] ").strip().lower()
+    return answer == "y"
+
+
+def run_react(task: str, max_steps: int = 8, log=print):
+    meter = Meter()
+    chat = Chat(SYSTEM, meter)                    # [axis 1] context: full history, every call
+    chat.add_user(task)
+
+    for step in range(max_steps):                 # [axis 3] termination: iteration cap
+        reply = chat.send()
+        if reply.text.strip():
+            log(f"[step {step + 1}] {reply.text.strip()}")
+
+        if not reply.tool_calls:                  # [axis 3] the model chose to finish
+            return reply.text, meter
+
+        approved = []
+        for call in reply.tool_calls:
+            if call.name in IRREVERSIBLE and not ask_human(call):
+                meter.interventions += 1          # [axis 5] intervention point
+                chat.add_tool_result(call, "denied: human did not approve")
+                continue
+            approved.append(call)
+        reply.tool_calls = approved
+        chat.run_tools(reply, log)                # [axis 2] granularity lives in tools_shared
+                                                  # [axis 4] errors come back as Observations
+
+    return "MAX_STEPS reached: incomplete", meter
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m = run_react(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions}")

--- a/submissions/26510126/week-02/logs/plan_exec-04.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-04.txt
@@ -1,0 +1,14 @@
+[plan] ['read_file app.log', 'count_pattern ERROR in app.log', 'tally ERRORs by hour', 'identify hour with most ERRORs', 'output HH:00']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+[step 1] Answer: 14:00
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Answer: 14:00
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 [0-9]{2}:.*ERROR'}) -> 19
+  [tool] count_pattern({'pattern': '^2026-09-01 14:.*ERROR', 'path': 'app.log'}) -> 6
+[step 3] Answer: 14:00
+[step 4] Answer: 14:00
+[step 5] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (395.5s)

--- a/submissions/26510126/week-02/logs/plan_exec-05.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-05.txt
@@ -1,0 +1,16 @@
+[plan] ['Read app.log', 'Extract ERROR log entries', 'Parse hour from each entry', 'Count occurrences per hour', 'Determine maximum count hour', 'Format as HH:00']
+[step 1] 
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'pattern': '^2026-09-01 [0-9]{2}:.*ERROR', 'path': 'app.log'}) -> 19
+[step 2] Answer: 14:00
+  [tool] count_pattern({'pattern': '^2026-09-01 09:.*ERROR', 'path': 'app.log'}) -> 1
+  [tool] count_pattern({'pattern': '^2026-09-01 10:.*ERROR', 'path': 'app.log'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 11:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.*ERROR'}) -> 3
+[step 3] OFF_PLAN: step exceeded the tool-call budget
+[replan] ['Read app.log', 'Extract ERROR log entries', 'Count occurrences per hour', 'Determine maximum count hour', 'Format as HH:00']
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 13:.*ERROR'}) -> 2
+  [tool] count_pattern({'pattern': '^2026-09-01 14:.*ERROR', 'path': 'app.log'}) -> 6
+crash: RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day', 'code': 429, 'metadata': {'headers': {'X-RateLimit-Limit': '50', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1788912000000'}, 'limit_source': 'openrouter_free_tier_daily', 'remedy_hint': 'Wait for the daily reset (see X-RateLimit-Reset), or purchase credits to raise your free-model daily limit.', 'provider_name': None}}, 'user_id': 'user_3Iit98tI48mcDKTaa97wOjcxoeV'}
+[final] 
+[judge] expected='14:00' -> X (449.1s)

--- a/submissions/26510126/week-02/logs/plan_exec-06.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-06.txt
@@ -1,0 +1,3 @@
+crash: RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day', 'code': 429, 'metadata': {'headers': {'X-RateLimit-Limit': '50', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1788912000000'}, 'limit_source': 'openrouter_free_tier_daily', 'remedy_hint': 'Wait for the daily reset (see X-RateLimit-Reset), or purchase credits to raise your free-model daily limit.', 'provider_name': None}}, 'user_id': 'user_3Iit98tI48mcDKTaa97wOjcxoeV'}
+[final] 
+[judge] expected='14:00' -> X (1.4s)

--- a/submissions/26510126/week-02/logs/plan_exec-10.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-10.txt
@@ -1,0 +1,51 @@
+[plan] ['read_file(app.log) to inspect timestamp format and range of hours', 'identify distinct hour values (HH) present in log entries', "for each hour HH, count_pattern(app.log, 'HH:00.*ERROR') to count ERROR lines in that hour", 'compare counts across all hours', 'select hour with the highest ERROR count', 'output that hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '09:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '10:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '11:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '15:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '16:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '17:.*ERROR'}) -> 1
+[step 1] Hour 14 has the highest count of ERROR lines (6), compared to at most 3 in any other hour.
+
+Answer: 14:00
+[step 2] Answer: The distinct hour values (HH) present in app.log are: 09, 10, 11, 12, 13, 14, 15, 16, 17.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '09:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '10:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log'}) -> error: count_pattern() missing 1 required positional argument: 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': '11:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '13:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '15:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '16:00.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '17:00.*ERROR'}) -> 0
+[step 3] Executed step 3 as specified in the plan, using the literal pattern `HH:00.*ERROR` for each identified hour (substituting HH with 09–17). Results:
+
+- 09:00 → 0
+- 10:00 → 0
+- 11:00 → 0
+- 12:00 → 0
+- 13:00 → 0
+- 14:00 → 0
+- 15:00 → 0
+- 16:00 → 0
+- 17:00 → 0
+
+Note: All counts are 0 because this pattern
+[step 4] Comparing the ERROR counts obtained for each hour (using the meaningful hour-wide match, since the literal `HH:00` pattern from step 3 returned 0 for every hour and provided no useful comparison):
+
+| Hour | ERROR count |
+|------|-------------|
+| 09:00 | 1 |
+| 10:00 | 2 |
+| 11:00 | 2 |
+| 12:00 | 3 |
+
+[step 5] Based on the comparison in step 4, the hour with the highest ERROR count is **14:00**, with 6 ERROR lines — surpassing all other hours (the next highest being 12:00 and 15:00, each with 3).
+[step 6] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (50.4s)

--- a/submissions/26510126/week-02/logs/plan_exec-11.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-11.txt
@@ -1,0 +1,37 @@
+[plan] ['read_file(app.log)', 'extract hour prefix from each ERROR line', 'count occurrences of ERROR per hour (HH:00)', 'identify hour with maximum ERROR count', 'answer with that hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+[step 1] Answer: 14:00
+[step 2] Based on the log content read in step 1, extracting the hour prefix (HH) from each line containing "ERROR":
+
+- 09:11:56 ERROR → **09**
+- 10:18:22 ERROR → **10**
+- 10:54:07 ERROR → **10**
+- 11:23:35 ERROR → **11**
+- 12:28:08 ERROR → **12**
+- 12:49:54 ERROR → **12**
+- 12:53:48 ERROR → **12**
+- 13:42:1
+[step 3] Tallying the hour prefixes extracted in step 2:
+
+| Hour (HH:00) | ERROR Count |
+|---|---|
+| 09:00 | 1 |
+| 10:00 | 2 |
+| 11:00 | 1 |
+| 12:00 | 3 |
+| 13:00 | 2 |
+| 14:00 | 6 |
+| 15:00 | 2 |
+| 16:00 | 1 |
+| 17:00 | 1 |
+
+(Total ERROR lines: 19, matching the count from step 2's extraction, and confirmed 
+[step 4] Comparing the counts from the table in step 3:
+
+09:00→1, 10:00→2, 11:00→1, 12:00→3, 13:00→2, **14:00→6**, 15:00→2, 16:00→1, 17:00→1
+
+The maximum count is **6**, occurring at **14:00**, which is clearly higher than all other hours.
+[step 5] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (22.5s)

--- a/submissions/26510126/week-02/logs/plan_exec-12.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-12.txt
@@ -1,0 +1,32 @@
+[plan] ['read_file(app.log)', 'identify distinct hour patterns (HH:00) present in log', "for each hour, count_pattern(app.log, 'HH:.*ERROR')", 'compare counts across hours', 'select hour with highest ERROR count', 'output that hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:.*ERROR'}) -> 3
+[step 1] 14:00 has 6 ERROR lines, the highest among all hours.
+
+Answer: 14:00
+[step 2] Distinct hour patterns present in app.log: 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00
+  [tool] count_pattern({'path': 'app.log', 'pattern': '09:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '10:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '11:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '15:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '16:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '17:.*ERROR'}) -> 1
+[step 3] ERROR counts per hour:
+- 09:00 → 1
+- 10:00 → 2
+- 11:00 → 2
+- 12:00 → 3
+- 13:00 → 2
+- 14:00 → 6
+- 15:00 → 3
+- 16:00 → 1
+- 17:00 → 1
+[step 4] Comparing the counts: 1, 2, 2, 3, 2, 6, 3, 1, 1 for hours 09:00–17:00 respectively — the maximum value is 6, occurring at 14:00, which is clearly higher than all other hours (the next highest are 12:00 and 15:00, each with 3).
+[step 5] Based on the comparison, the hour with the highest ERROR count is **14:00**, with 6 ERROR lines — the maximum among all hours in the log.
+[step 6] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (31.2s)

--- a/submissions/26510126/week-02/logs/plan_exec-16.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-16.txt
@@ -1,0 +1,49 @@
+[plan] ['read_file(app.log)', 'extract hour field from each ERROR line', "count_pattern(app.log, 'ERROR') for each hour HH:00", 'compare counts across hours 00:00-23:00', 'identify hour with maximum ERROR count', 'output that hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 1] Answer: 14:00
+[step 2] Extracting the HH portion from the timestamp of every line containing "ERROR" (based on the file contents read in step 1):
+
+- 09:11:56 → 09
+- 10:18:22 → 10
+- 10:54:07 → 10
+- 11:23:35 → 11
+- 12:28:08 → 12
+- 12:49:54 → 12
+- 12:53:48 → 12
+- 13:42:13 → 13
+- 13:59:54 → 13
+- 14:04:06 → 14
+- 14:07:11 → 14
+
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 3] Counts of ERROR lines per hour:
+
+- 09:00 → 1
+- 10:00 → 2
+- 11:00 → 1
+- 12:00 → 3
+- 13:00 → 2
+- 14:00 → 6
+- 15:00 → 2
+- 16:00 → 1
+- 17:00 → 1
+[step 4] Comparing ERROR counts across all possible hours 00:00–23:00 (hours not returned by the tool had zero ERROR lines):
+
+- 00:00–08:00 → 0 each
+- 09:00 → 1
+- 10:00 → 2
+- 11:00 → 1
+- 12:00 → 3
+- 13:00 → 2
+- 14:00 → 6  ← highest
+- 15:00 → 2
+- 16:00 → 1
+- 17:00 → 1
+- 18:00–23:00 → 0 each
+
+The maximum count
+[step 5] Step 5 result: The hour with the maximum ERROR count is **14:00**, with 6 ERROR lines — more than any other hour in the 00:00–23:00 range.
+[step 6] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (28.8s)

--- a/submissions/26510126/week-02/logs/plan_exec-17.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-17.txt
@@ -1,0 +1,51 @@
+[plan] ['read_file(app.log)', "count_pattern(app.log, 'ERROR')", "count_pattern(app.log, '00:.*ERROR') for each hour 00-23", 'compare counts per hour', 'identify hour with max ERROR count', 'output answer in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 1] Answer: 14:00
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 2] Total ERROR lines: 1+2+1+3+2+6+2+1+1 = 19
+
+Per-hour breakdown (from count_by_hour, since no plain total-count tool exists):
+- 09:00 → 1
+- 10:00 → 2
+- 11:00 → 1
+- 12:00 → 3
+- 13:00 → 2
+- 14:00 → 6
+- 15:00 → 2
+- 16:00 → 1
+- 17:00 → 1
+[step 3] OFF_PLAN: There is no count_pattern tool available, and looping a literal pattern '00:.*ERROR' for each hour 00-23 doesn't align with the available count_by_hour tool, which already groups ERROR matches by hour in a single call (as done in Step 2, giving counts for 09:00–17:00). Running 24 separate 
+[replan] ['read_file(app.log)', "count_pattern(app.log, 'ERROR')", "count_by_hour(app.log, 'ERROR')", 'compare counts per hour from result', 'identify hour with max ERROR count', 'output answer in HH:00 format']
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 3] Per-hour ERROR counts:
+- 09:00 → 1
+- 10:00 → 2
+- 11:00 → 1
+- 12:00 → 3
+- 13:00 → 2
+- 14:00 → 6
+- 15:00 → 2
+- 16:00 → 1
+- 17:00 → 1
+
+Maximum is at 14:00 with 6 ERROR lines.
+[step 4] Comparing all hourly ERROR counts:
+
+| Hour | Count |
+|------|-------|
+| 09:00 | 1 |
+| 10:00 | 2 |
+| 11:00 | 1 |
+| 12:00 | 3 |
+| 13:00 | 2 |
+| 14:00 | **6** ← highest |
+| 15:00 | 2 |
+| 16:00 | 1 |
+| 17:00 | 1 |
+
+The hour 14:00 has the highest count (6), exceeding all other hours by at least 3.
+[step 5] Step 5 result: The hour with the maximum ERROR count is **14:00**, with 6 ERROR lines — the highest among all hours in app.log.
+[step 6] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (40.4s)

--- a/submissions/26510126/week-02/logs/plan_exec-18.txt
+++ b/submissions/26510126/week-02/logs/plan_exec-18.txt
@@ -1,0 +1,21 @@
+[plan] ['read_file(app.log) to inspect log format and timestamp range', 'identify distinct hour values (HH:00) present in the log', "for each candidate hour, run count_pattern(app.log, 'HH:00.*ERROR') to count ERROR lines in that hour", 'compare counts across all hours', 'select hour with highest ERROR count', 'report that hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 1] Answer: 14:00
+[step 2] Answer: The distinct hour values (HH:00) present in app.log are: 09:00, 10:00, 11:00, 12:00, 13:00, 14:00, 15:00, 16:00, 17:00
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 3] Answer: ERROR line counts per hour (using count_by_hour, equivalent to per-hour 'HH:00.*ERROR' matching):
+- 09:00: 1
+- 10:00: 2
+- 11:00: 1
+- 12:00: 3
+- 13:00: 2
+- 14:00: 6
+- 15:00: 2
+- 16:00: 1
+- 17:00: 1
+[step 4] Answer: Comparing all counts — 09:00:1, 10:00:2, 11:00:1, 12:00:3, 13:00:2, 14:00:6, 15:00:2, 16:00:1, 17:00:1 — the maximum value is 6, occurring at 14:00. All other hours have counts of 3 or fewer, so 14:00 is clearly the highest.
+[step 5] Answer: 14:00 (with 6 ERROR lines, the highest count among all hours)
+[step 6] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (24.7s)

--- a/submissions/26510126/week-02/logs/react-01.txt
+++ b/submissions/26510126/week-02/logs/react-01.txt
@@ -1,0 +1,10 @@
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'pattern': '^2026-09-01 09:.*ERROR', 'path': 'app.log'}) -> 1
+  [tool] count_pattern({'pattern': '^2026-09-01 10:.*ERROR', 'path': 'app.log'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 11:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+  [tool] count_pattern({'pattern': '^2026-09-01 15:.*ERROR', 'path': 'app.log'}) -> 2
+[final] MAX_STEPS reached: incomplete
+[judge] expected='14:00' -> X (56.3s)

--- a/submissions/26510126/week-02/logs/react-02.txt
+++ b/submissions/26510126/week-02/logs/react-02.txt
@@ -1,0 +1,8 @@
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Thought: I examined the log file and identified all lines containing "ERROR". I extracted the hour (HH) from each ERROR line and counted occurrences per hour. Hour 14 appears 6 times, which is the highest count. Therefore, the hour with the most ERROR lines is 14:00.
+
+Answer: 14:00
+[final] Thought: I examined the log file and identified all lines containing "ERROR". I extracted the hour (HH) from each ERROR line and counted occurrences per hour. Hour 14 appears 6 times, which is the highest count. Therefore, the hour with the most ERROR lines is 14:00.
+
+Answer: 14:00
+[judge] expected='14:00' -> O (43.1s)

--- a/submissions/26510126/week-02/logs/react-03.txt
+++ b/submissions/26510126/week-02/logs/react-03.txt
@@ -1,0 +1,8 @@
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Thought: I examined the log file and identified all lines containing "ERROR". I extracted the hour from each ERROR line and counted occurrences per hour. Hour 14 appears 6 times, which is the highest count (others have at most 3). Therefore, the hour with the most ERROR lines is 14:00.
+
+Answer: 14:00
+[final] Thought: I examined the log file and identified all lines containing "ERROR". I extracted the hour from each ERROR line and counted occurrences per hour. Hour 14 appears 6 times, which is the highest count (others have at most 3). Therefore, the hour with the most ERROR lines is 14:00.
+
+Answer: 14:0
+[judge] expected='14:00' -> O (26.4s)

--- a/submissions/26510126/week-02/logs/react-07.txt
+++ b/submissions/26510126/week-02/logs/react-07.txt
@@ -1,0 +1,5 @@
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+[step 3] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (9.1s)

--- a/submissions/26510126/week-02/logs/react-08.txt
+++ b/submissions/26510126/week-02/logs/react-08.txt
@@ -1,0 +1,6 @@
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.*ERROR'}) -> 3
+[step 3] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (6.6s)

--- a/submissions/26510126/week-02/logs/react-09.txt
+++ b/submissions/26510126/week-02/logs/react-09.txt
@@ -1,0 +1,5 @@
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+[step 3] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (6.6s)

--- a/submissions/26510126/week-02/logs/react-13.txt
+++ b/submissions/26510126/week-02/logs/react-13.txt
@@ -1,0 +1,5 @@
+[step 1] Thought: I need to count ERROR lines by hour in app.log to find the peak hour.
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 2] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (4.0s)

--- a/submissions/26510126/week-02/logs/react-14.txt
+++ b/submissions/26510126/week-02/logs/react-14.txt
@@ -1,0 +1,5 @@
+[step 1] Thought: I need to count ERROR lines per hour in app.log using the count_by_hour tool.
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 2] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (3.2s)

--- a/submissions/26510126/week-02/logs/react-15.txt
+++ b/submissions/26510126/week-02/logs/react-15.txt
@@ -1,0 +1,5 @@
+[step 1] Thought: I need to count ERROR lines in app.log grouped by hour to find which hour has the most occurrences.
+  [tool] count_by_hour({'path': 'app.log', 'pattern': 'ERROR'}) -> 09:00 1 | 10:00 2 | 11:00 1 | 12:00 3 | 13:00 2 | 14:00 6 | 15:00 2 | 16:00 1 | 17:00 1
+[step 2] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (3.1s)

--- a/submissions/26510126/week-02/logs_early/plan_exec_early-01.txt
+++ b/submissions/26510126/week-02/logs_early/plan_exec_early-01.txt
@@ -1,0 +1,14 @@
+[plan] ["read_file(path='app.log')", "count_pattern(path='app.log', pattern='00:.*ERROR')", "count_pattern(path='app.log', pattern='01:.*ERROR')", "count_pattern(path='app.log', pattern='02:.*ERROR')", "count_pattern(path='app.log', pattern='03:.*ERROR')", "count_pattern(path='app.log', pattern='04:.*ERROR')", "count_pattern(path='app.log', pattern='05:.*ERROR')", "count_pattern(path='app.log', pattern='06:.*ERROR')", "count_pattern(path='app.log', pattern='07:.*ERROR')", "count_pattern(path='app.log', pattern='08:.*ERROR')", "count_pattern(path='app.log', pattern='09:.*ERROR')", "count_pattern(path='app.log', pattern='10:.*ERROR')", "count_pattern(path='app.log', pattern='11:.*ERROR')", "count_pattern(path='app.log', pattern='12:.*ERROR')", "count_pattern(path='app.log', pattern='13:.*ERROR')", "count_pattern(path='app.log', pattern='14:.*ERROR')", "count_pattern(path='app.log', pattern='15:.*ERROR')", "count_pattern(path='app.log', pattern='16:.*ERROR')", "count_pattern(path='app.log', pattern='17:.*ERROR')", "count_pattern(path='app.log', pattern='18:.*ERROR')", "count_pattern(path='app.log', pattern='19:.*ERROR')", "count_pattern(path='app.log', pattern='20:.*ERROR')", "count_pattern(path='app.log', pattern='21:.*ERROR')", "count_pattern(path='app.log', pattern='22:.*ERROR')", "count_pattern(path='app.log', pattern='23:.*ERROR')", 'compare counts for each hour and identify the hour with the maximum ERROR count', 'output the hour in HH:00 format with the highest count']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '09:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '10:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '11:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '15:.*ERROR'}) -> 3
+  [tool] count_pattern({}) -> error: count_pattern() missing 2 required positional arguments: 'path' and 'pattern'
+[step 1] Answer: 14:00
+[early exit] answered at step 1; 26 step(s) skipped, no final call
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (19.3s)

--- a/submissions/26510126/week-02/logs_early/plan_exec_early-02.txt
+++ b/submissions/26510126/week-02/logs_early/plan_exec_early-02.txt
@@ -1,0 +1,114 @@
+[plan] ['read_file(app.log)', "count_pattern(app.log, 'ERROR')", "count_pattern(app.log, '00:00 ERROR')", "count_pattern(app.log, '01:00 ERROR')", "count_pattern(app.log, '02:00 ERROR')", "count_pattern(app.log, '03:00 ERROR')", "count_pattern(app.log, '04:00 ERROR')", "count_pattern(app.log, '05:00 ERROR')", "count_pattern(app.log, '06:00 ERROR')", "count_pattern(app.log, '07:00 ERROR')", "count_pattern(app.log, '08:00 ERROR')", "count_pattern(app.log, '09:00 ERROR')", "count_pattern(app.log, '10:00 ERROR')", "count_pattern(app.log, '11:00 ERROR')", "count_pattern(app.log, '12:00 ERROR')", "count_pattern(app.log, '13:00 ERROR')", "count_pattern(app.log, '14:00 ERROR')", "count_pattern(app.log, '15:00 ERROR')", "count_pattern(app.log, '16:00 ERROR')", "count_pattern(app.log, '17:00 ERROR')", "count_pattern(app.log, '18:00 ERROR')", "count_pattern(app.log, '19:00 ERROR')", "count_pattern(app.log, '20:00 ERROR')", "count_pattern(app.log, '21:00 ERROR')", "count_pattern(app.log, '22:00 ERROR')", "count_pattern(app.log, '23:00 ERROR')", 'compare counts and determine hour with maximum ERROR lines', 'output the hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 1] I have read the contents of `app.log`. It contains log entries spanning hours 09:00 through 17:00 on 2026‑09‑01, with a mix of INFO, WARN, and ERROR lines. This completes step 1 of the plan (reading the file). The next steps in the plan would involve counting ERROR occurrences per hour.
+  [tool] count_pattern({'path': 'app.log', 'pattern': 'ERROR'}) -> 19
+[step 2] Step 2 complete: there are **19** total lines containing "ERROR" in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '00:00 ERROR'}) -> 0
+[step 3] Step 3 complete: the pattern `'00:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '01:00 ERROR'}) -> 0
+[step 4] Step 4 complete: the pattern `'01:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '02:00 ERROR'}) -> 0
+[step 5] Step 5 complete: the pattern `'02:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '03:00 ERROR'}) -> 0
+[step 6] Step 6 complete: the pattern `'03:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '04:00 ERROR'}) -> 0
+[step 7] Step 7 complete: the pattern `'04:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '05:00 ERROR'}) -> 0
+[step 8] Step 8 complete: the pattern `'05:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '06:00 ERROR'}) -> 0
+[step 9] Step 9 complete: the pattern `'06:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '07:00 ERROR'}) -> 0
+[step 10] Step 10 complete: the pattern `'07:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '08:00 ERROR'}) -> 0
+[step 11] Step 11 complete: the pattern `'08:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '09:00 ERROR'}) -> 0
+[step 12] Step 12 complete: the pattern `'09:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '10:00 ERROR'}) -> 0
+[step 13] Step 13 complete: the pattern `'10:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '11:00 ERROR'}) -> 0
+[step 14] Step 14 complete: the pattern `'11:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:00 ERROR'}) -> 0
+[step 15] Step 15 complete: the pattern `'12:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '13:00 ERROR'}) -> 0
+[step 16] Step 16 complete: the pattern `'13:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:00 ERROR'}) -> 0
+[step 17] Step 17 complete: the pattern `'14:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '15:00 ERROR'}) -> 0
+[step 18] Step 18 complete: the pattern `'15:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '16:00 ERROR'}) -> 0
+[step 19] Step 19 complete: the pattern `'16:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '17:00 ERROR'}) -> 0
+[step 20] Step 20 complete: the pattern `'17:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '18:00 ERROR'}) -> 0
+[step 21] Step 21 complete: the pattern `'18:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '19:00 ERROR'}) -> 0
+[step 22] Step 22 complete: the pattern `'19:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '20:00 ERROR'}) -> 0
+[step 23] Step 23 complete: the pattern `'20:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '21:00 ERROR'}) -> 0
+[step 24] Step 24 complete: the pattern `'21:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '22:00 ERROR'}) -> 0
+[step 25] Step 25 complete: the pattern `'22:00 ERROR'` matched **0** lines in app.log.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '23:00 ERROR'}) -> 0
+[step 26] Step 26 complete: the pattern `'23:00 ERROR'` matched **0** lines in app.log.
+[step 27] OFF_PLAN: The counts gathered in steps 3–26 are all 0 for every hour (`'00:00 ERROR'` through `'23:00 ERROR'`), because the pattern used (`HH:00 ERROR`) only matches log lines where the **minute** field is exactly `00`, not the hour. Since the timestamps in app.log have varying minutes/seconds (e.g.
+[replan] ['read_file(app.log)', "count_pattern(app.log, 'ERROR')", "count_pattern(app.log, '00:00 ERROR')", "count_pattern(app.log, '01:00 ERROR')", "count_pattern(app.log, '02:00 ERROR')", "count_pattern(app.log, '03:00 ERROR')", "count_pattern(app.log, '04:00 ERROR')", "count_pattern(app.log, '05:00 ERROR')", "count_pattern(app.log, '06:00 ERROR')", "count_pattern(app.log, '07:00 ERROR')", "count_pattern(app.log, '08:00 ERROR')", "count_pattern(app.log, '09:00 ERROR')", "count_pattern(app.log, '10:00 ERROR')", "count_pattern(app.log, '11:00 ERROR')", "count_pattern(app.log, '12:00 ERROR')", "count_pattern(app.log, '13:00 ERROR')", "count_pattern(app.log, '14:00 ERROR')", "count_pattern(app.log, '15:00 ERROR')", "count_pattern(app.log, '16:00 ERROR')", "count_pattern(app.log, '17:00 ERROR')", "count_pattern(app.log, '18:00 ERROR')", "count_pattern(app.log, '19:00 ERROR')", "count_pattern(app.log, '20:00 ERROR')", "count_pattern(app.log, '21:00 ERROR')", "count_pattern(app.log, '22:00 ERROR')", "count_pattern(app.log, '23:00 ERROR')", "count_pattern(app.log, '00: ERROR')", "count_pattern(app.log, '01: ERROR')", "count_pattern(app.log, '02: ERROR')", "count_pattern(app.log, '03: ERROR')", "count_pattern(app.log, '04: ERROR')", "count_pattern(app.log, '05: ERROR')", "count_pattern(app.log, '06: ERROR')", "count_pattern(app.log, '07: ERROR')", "count_pattern(app.log, '08: ERROR')", "count_pattern(app.log, '09: ERROR')", "count_pattern(app.log, '10: ERROR')", "count_pattern(app.log, '11: ERROR')", "count_pattern(app.log, '12: ERROR')", "count_pattern(app.log, '13: ERROR')", "count_pattern(app.log, '14: ERROR')", "count_pattern(app.log, '15: ERROR')", "count_pattern(app.log, '16: ERROR')", "count_pattern(app.log, '17: ERROR')", "count_pattern(app.log, '18: ERROR')", "count_pattern(app.log, '19: ERROR')", "count_pattern(app.log, '20: ERROR')", "count_pattern(app.log, '21: ERROR')", "count_pattern(app.log, '22: ERROR')", "count_pattern(app.log, '23: ERROR')", 'compare counts and determine hour with maximum ERROR lines', 'output the hour in HH:00 format']
+  [tool] count_pattern({'path': 'app.log', 'pattern': '00: ERROR'}) -> 0
+[step 27] Step 27 complete: the pattern `'00: ERROR'` matched **0** lines in app.log.
+
+Note: This pattern still doesn't align with the actual log format (`HH:MM:SS LEVEL`), so it won't correctly capture hour-based ERROR counts either. Based on my earlier direct reading of the file (step 1), I can already dete
+  [tool] count_pattern({'path': 'app.log', 'pattern': '01: ERROR'}) -> 0
+[step 28] Step 28 complete: the pattern `'01: ERROR'` matched **0** lines in app.log (as expected, since this pattern format doesn't align with the `HH:MM:SS LEVEL` structure of the log and no log entries exist for the 01:00 hour anyway).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '02: ERROR'}) -> 0
+[step 29] Step 29 complete: the pattern `'02: ERROR'` matched **0** lines in app.log (consistent with expectations, since no log entries exist for the 02:00 hour and the pattern format doesn't match the log's actual structure).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '03: ERROR'}) -> 0
+[step 30] Step 30 complete: the pattern `'03: ERROR'` matched **0** lines in app.log (as expected — no entries exist for the 03:00 hour, and this pattern still doesn't match the log's actual `HH:MM:SS LEVEL` format).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '04: ERROR'}) -> 0
+[step 31] Step 31 complete: the pattern `'04: ERROR'` matched **0** lines in app.log (expected, as no log entries exist for the 04:00 hour).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '05: ERROR'}) -> 0
+[step 32] Step 32 complete: the pattern `'05: ERROR'` matched **0** lines in app.log (expected — no entries exist for the 05:00 hour).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '06: ERROR'}) -> 0
+[step 33] Step 33 complete: the pattern `'06: ERROR'` matched **0** lines in app.log (expected — no log entries exist for the 06:00 hour).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '07: ERROR'}) -> 0
+[step 34] Step 34 complete: the pattern `'07: ERROR'` matched **0** lines in app.log (expected — no log entries exist for the 07:00 hour).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '08: ERROR'}) -> 0
+[step 35] Step 35 complete: the pattern `'08: ERROR'` matched **0** lines in app.log (expected — no log entries exist for the 08:00 hour).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '09: ERROR'}) -> 0
+[step 36] Step 36 complete: the pattern `'09: ERROR'` matched **0** lines in app.log — even though the 09:00 hour does have 1 ERROR line (`09:11:56 ERROR`), the pattern `'09: ERROR'` doesn't match because the actual format is `09:11:56 ERROR` (hour:minute:second, then level), not `09: ERROR`.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '10: ERROR'}) -> 0
+[step 37] Step 37 complete: the pattern `'10: ERROR'` matched **0** lines in app.log — although the 10:00 hour has 2 ERROR lines (`10:18:22 ERROR` and `10:54:07 ERROR`), the pattern doesn't match because the format is `HH:MM:SS ERROR`, not `HH: ERROR`.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '11: ERROR'}) -> 0
+[step 38] Step 38 complete: the pattern `'11: ERROR'` matched **0** lines in app.log — although the 11:00 hour has 1 ERROR line (`11:23:35 ERROR`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS ERROR` vs `HH: ERROR`).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12: ERROR'}) -> 0
+[step 39] Step 39 complete: the pattern `'12: ERROR'` matched **0** lines in app.log — although the 12:00 hour actually has 3 ERROR lines (`12:28:08`, `12:49:54`, `12:53:48`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS ERROR` vs `HH: ERROR`).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '13: ERROR'}) -> 0
+[step 40] Step 40 complete: the pattern `'13: ERROR'` matched **0** lines in app.log — although the 13:00 hour actually has 2 ERROR lines (`13:42:13` and `13:59:54`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS ERROR` vs `HH: ERROR`).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14: ERROR'}) -> 0
+[step 41] Step 41 complete: the pattern `'14: ERROR'` matched **0** lines in app.log — although the 14:00 hour actually has **6 ERROR lines** (the highest of any hour: `14:04:06`, `14:07:11`, `14:15:56`, `14:30:20`, `14:47:03`, `14:54:53`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS 
+  [tool] count_pattern({'path': 'app.log', 'pattern': '15: ERROR'}) -> 0
+[step 42] Step 42 complete: the pattern `'15: ERROR'` matched **0** lines in app.log — although the 15:00 hour actually has 2 ERROR lines (`15:34:38` and `15:41:14`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS ERROR` vs `HH: ERROR`).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '16: ERROR'}) -> 0
+[step 43] Step 43 complete: the pattern `'16: ERROR'` matched **0** lines in app.log — although the 16:00 hour actually has 1 ERROR line (`16:53:34`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS ERROR` vs `HH: ERROR`).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '17: ERROR'}) -> 0
+[step 44] Step 44 complete: the pattern `'17: ERROR'` matched **0** lines in app.log — although the 17:00 hour actually has 1 ERROR line (`17:17:14`), the pattern doesn't match due to the same format mismatch (`HH:MM:SS ERROR` vs `HH: ERROR`).
+
+**Summary of all pattern-matching attempts (steps 3–44):** Every 
+  [tool] count_pattern({'path': 'app.log', 'pattern': '18: ERROR'}) -> 0
+[step 45] Step 45 complete: the pattern `'18: ERROR'` matched **0** lines in app.log — consistent with expectations, since no log entries exist for the 18:00 hour at all.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '19: ERROR'}) -> 0
+[step 46] Step 46 complete: the pattern `'19: ERROR'` matched **0** lines in app.log — expected, since no log entries exist for the 19:00 hour.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '20: ERROR'}) -> 0
+[step 47] Step 47 complete: the pattern `'20: ERROR'` matched **0** lines in app.log — expected, since no log entries exist for the 20:00 hour.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '21: ERROR'}) -> 0
+[step 48] Step 48 complete: the pattern `'21: ERROR'` matched **0** lines in app.log — expected, since no log entries exist for the 21:00 hour.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '22: ERROR'}) -> 0
+[step 49] Step 49 complete: the pattern `'22: ERROR'` matched **0** lines in app.log — expected, since no log entries exist for the 22:00 hour.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '23: ERROR'}) -> 0
+[step 50] Step 50 complete: the pattern `'23: ERROR'` matched **0** lines in app.log — expected, since no log entries exist for the 23:00 hour.
+
+**Final tally across all 50 pattern-matching attempts:** Every automated regex pattern returned 0 matches due to format mismatches with the log's actual `HH:MM:SS LE
+[early exit] answered at step 50; 2 step(s) skipped, no final call
+[final] Step 50 complete: the pattern `'23: ERROR'` matched **0** lines in app.log — expected, since no log entries exist for the 23:00 hour.
+
+**Final tally across all 50 pattern-matching attempts:** Every automated regex pattern returned 0 matches due to format mismatches with the log's actual `HH:MM:SS LE
+[judge] expected='14:00' -> O (235.8s)

--- a/submissions/26510126/week-02/logs_early/plan_exec_early-03.txt
+++ b/submissions/26510126/week-02/logs_early/plan_exec_early-03.txt
@@ -1,0 +1,8 @@
+[plan] ['read_file(app.log)', "count_pattern(app.log, '00:.*ERROR')", "count_pattern(app.log, '01:.*ERROR')", "count_pattern(app.log, '02:.*ERROR')", "count_pattern(app.log, '03:.*ERROR')", "count_pattern(app.log, '04:.*ERROR')", "count_pattern(app.log, '05:.*ERROR')", "count_pattern(app.log, '06:.*ERROR')", "count_pattern(app.log, '07:.*ERROR')", "count_pattern(app.log, '08:.*ERROR')", "count_pattern(app.log, '09:.*ERROR')", "count_pattern(app.log, '10:.*ERROR')", "count_pattern(app.log, '11:.*ERROR')", "count_pattern(app.log, '12:.*ERROR')", "count_pattern(app.log, '13:.*ERROR')", "count_pattern(app.log, '14:.*ERROR')", "count_pattern(app.log, '15:.*ERROR')", "count_pattern(app.log, '16:.*ERROR')", "count_pattern(app.log, '17:.*ERROR')", "count_pattern(app.log, '18:.*ERROR')", "count_pattern(app.log, '19:.*ERROR')", "count_pattern(app.log, '20:.*ERROR')", "count_pattern(app.log, '21:.*ERROR')", "count_pattern(app.log, '22:.*ERROR')", "count_pattern(app.log, '23:.*ERROR')", 'compare counts across all hours', 'identify hour with maximum ERROR count', 'output that hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+  [tool] count_pattern({'path': 'app.log', 'pattern': '14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '12:.*ERROR'}) -> 3
+[step 1] Answer: 14:00
+[early exit] answered at step 1; 27 step(s) skipped, no final call
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (13.8s)

--- a/submissions/26510126/week-02/results.csv
+++ b/submissions/26510126/week-02/results.csv
@@ -11,3 +11,9 @@ run,harness,success,tokens,iters,interventions,note
 10,plan_exec,O,55054,12,0,anthropic:claude-sonnet-5 replans=0
 11,plan_exec,O,24088,9,0,anthropic:claude-sonnet-5 replans=0
 12,plan_exec,O,34920,11,0,anthropic:claude-sonnet-5 replans=0
+13,react,O,1688,2,0,anthropic:claude-sonnet-5 tools=coarse
+14,react,O,1744,2,0,anthropic:claude-sonnet-5 tools=coarse
+15,react,O,1704,2,0,anthropic:claude-sonnet-5 tools=coarse
+16,plan_exec,O,31956,11,0,anthropic:claude-sonnet-5 tools=coarse replans=0
+17,plan_exec,O,41006,14,0,anthropic:claude-sonnet-5 tools=coarse replans=1
+18,plan_exec,O,28841,11,0,anthropic:claude-sonnet-5 tools=coarse replans=0

--- a/submissions/26510126/week-02/results.csv
+++ b/submissions/26510126/week-02/results.csv
@@ -1,0 +1,7 @@
+run,harness,success,tokens,iters,interventions,note
+1,react,X,22803,8,0,
+2,react,O,3833,2,0,
+3,react,O,3785,2,0,
+4,plan_exec,O,53613,13,0,replans=0
+5,plan_exec,X,,,,"crash: RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day', 'code': 429, 'metadata': {'headers': {'X-RateLimit-Limit': '50', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1788912000000'}, 'limit_source': 'openrouter_free_tier_daily', 'remedy_hint': 'Wait for the daily reset (see X-RateLimit-Reset), or purchase credits to raise your free-model daily limit.', 'provider_name': None}}, 'user_id': 'user_3Iit98tI48mcDKTaa97wOjcxoeV'}"
+6,plan_exec,X,,,,"crash: RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day', 'code': 429, 'metadata': {'headers': {'X-RateLimit-Limit': '50', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1788912000000'}, 'limit_source': 'openrouter_free_tier_daily', 'remedy_hint': 'Wait for the daily reset (see X-RateLimit-Reset), or purchase credits to raise your free-model daily limit.', 'provider_name': None}}, 'user_id': 'user_3Iit98tI48mcDKTaa97wOjcxoeV'}"

--- a/submissions/26510126/week-02/results.csv
+++ b/submissions/26510126/week-02/results.csv
@@ -5,3 +5,9 @@ run,harness,success,tokens,iters,interventions,note
 4,plan_exec,O,53613,13,0,replans=0
 5,plan_exec,X,,,,"crash: RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day', 'code': 429, 'metadata': {'headers': {'X-RateLimit-Limit': '50', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1788912000000'}, 'limit_source': 'openrouter_free_tier_daily', 'remedy_hint': 'Wait for the daily reset (see X-RateLimit-Reset), or purchase credits to raise your free-model daily limit.', 'provider_name': None}}, 'user_id': 'user_3Iit98tI48mcDKTaa97wOjcxoeV'}"
 6,plan_exec,X,,,,"crash: RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day', 'code': 429, 'metadata': {'headers': {'X-RateLimit-Limit': '50', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1788912000000'}, 'limit_source': 'openrouter_free_tier_daily', 'remedy_hint': 'Wait for the daily reset (see X-RateLimit-Reset), or purchase credits to raise your free-model daily limit.', 'provider_name': None}}, 'user_id': 'user_3Iit98tI48mcDKTaa97wOjcxoeV'}"
+7,react,O,6154,3,0,anthropic:claude-sonnet-5
+8,react,O,5895,3,0,anthropic:claude-sonnet-5
+9,react,O,5861,3,0,anthropic:claude-sonnet-5
+10,plan_exec,O,55054,12,0,anthropic:claude-sonnet-5 replans=0
+11,plan_exec,O,24088,9,0,anthropic:claude-sonnet-5 replans=0
+12,plan_exec,O,34920,11,0,anthropic:claude-sonnet-5 replans=0

--- a/submissions/26510126/week-02/results_early.csv
+++ b/submissions/26510126/week-02/results_early.csv
@@ -1,0 +1,4 @@
+run,harness,success,tokens,iters,interventions,note
+1,plan_exec_early,O,10666,4,0,anthropic:claude-sonnet-5 tools=fine replans=0
+2,plan_exec_early,O,876769,103,0,anthropic:claude-sonnet-5 tools=fine replans=1
+3,plan_exec_early,O,8967,4,0,anthropic:claude-sonnet-5 tools=fine replans=0

--- a/submissions/26510126/week-02/run_ab.py
+++ b/submissions/26510126/week-02/run_ab.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from harness_plan_execute import run_plan_execute
 from harness_react import run_react
-from tools_shared import MODEL, PROVIDER
+from tools_shared import MODEL, PROVIDER, TOOLSET
 
 HEADER = ["run", "harness", "success", "tokens", "iters", "interventions", "note"]
 
@@ -77,7 +77,7 @@ def main():
                 t0 = time.time()
                 # Which model produced the row belongs in the row. Mixing two
                 # providers in one results.csv is otherwise unreadable later.
-                note = f"{PROVIDER}:{MODEL}"
+                note = f"{PROVIDER}:{MODEL} tools={TOOLSET}"
                 try:
                     out = fn(task, log=log)
                     answer, meter = out[0], out[1]

--- a/submissions/26510126/week-02/run_ab.py
+++ b/submissions/26510126/week-02/run_ab.py
@@ -30,9 +30,21 @@ def read_task(path="TASK.md"):
 
 
 def judge(answer: str, expected: str) -> bool:
-    """Success = the expected string appears in the final answer. Fix the
-    criterion in TASK.md before running; do not loosen it afterwards."""
-    return expected.lower() in (answer or "").lower()
+    """Success = the expected string appears in the harness's conclusion.
+
+    The conclusion is the last line beginning with 'Answer:'; both harnesses
+    are instructed to emit one. Falling back to the whole response when there
+    is none. Checking the whole response instead would score a run O whenever
+    it merely mentioned the expected hour while concluding otherwise, and the
+    two harnesses do not produce final responses of the same shape, so that
+    bias would not fall equally on them.
+
+    Fixed before the first run. Do not loosen it afterwards.
+    """
+    text = answer or ""
+    lines = [l for l in text.splitlines() if l.strip().lower().startswith("answer:")]
+    target = lines[-1] if lines else text
+    return expected.lower() in target.lower()
 
 
 def main():

--- a/submissions/26510126/week-02/run_ab.py
+++ b/submissions/26510126/week-02/run_ab.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from harness_plan_execute import run_plan_execute
 from harness_react import run_react
+from tools_shared import MODEL, PROVIDER
 
 HEADER = ["run", "harness", "success", "tokens", "iters", "interventions", "note"]
 
@@ -74,14 +75,17 @@ def main():
                     _lines.append(str(msg))
 
                 t0 = time.time()
-                note = ""
+                # Which model produced the row belongs in the row. Mixing two
+                # providers in one results.csv is otherwise unreadable later.
+                note = f"{PROVIDER}:{MODEL}"
                 try:
                     out = fn(task, log=log)
                     answer, meter = out[0], out[1]
                     if name == "plan_exec":
-                        note = f"replans={out[2]}"
+                        note += f" replans={out[2]}"
                 except Exception as e:            # a crash is a failed run, not a lost run
-                    answer, meter, note = "", None, f"crash: {type(e).__name__}: {e}"
+                    answer, meter = "", None
+                    note += f" crash: {type(e).__name__}: {e}"
                     log(note)
                 success = judge(answer, expected)
                 log(f"[final] {answer.strip()[:300]}")

--- a/submissions/26510126/week-02/run_ab.py
+++ b/submissions/26510126/week-02/run_ab.py
@@ -1,0 +1,90 @@
+"""Week 02 starter — run the A/B experiment and record results.csv.
+
+Usage: python run_ab.py [--runs 3]
+
+Reads the task and the success criterion from TASK.md, runs each harness
+--runs times, judges every run, appends one line per run to results.csv,
+and saves each run's console output under logs/. Failed runs are kept:
+they are data.
+"""
+import argparse
+import csv
+import os
+import re
+import time
+from pathlib import Path
+
+from harness_plan_execute import run_plan_execute
+from harness_react import run_react
+
+HEADER = ["run", "harness", "success", "tokens", "iters", "interventions", "note"]
+
+
+def read_task(path="TASK.md"):
+    text = Path(path).read_text(encoding="utf-8")
+    task = re.search(r"^task:\s*(.+)$", text, flags=re.M)
+    expected = re.search(r"^expected:\s*(.+)$", text, flags=re.M)
+    if not task or not expected:
+        raise SystemExit("TASK.md needs a 'task:' line and an 'expected:' line")
+    return task.group(1).strip(), expected.group(1).strip()
+
+
+def judge(answer: str, expected: str) -> bool:
+    """Success = the expected string appears in the final answer. Fix the
+    criterion in TASK.md before running; do not loosen it afterwards."""
+    return expected.lower() in (answer or "").lower()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=3)
+    args = ap.parse_args()
+
+    task, expected = read_task()
+    Path("logs").mkdir(exist_ok=True)
+    new_file = not Path("results.csv").exists()
+    run_no = 0
+    if not new_file:
+        with open("results.csv", encoding="utf-8") as f:
+            run_no = sum(1 for _ in f) - 1
+
+    with open("results.csv", "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new_file:
+            w.writerow(HEADER)
+        for name, fn in (("react", run_react), ("plan_exec", run_plan_execute)):
+            for _ in range(args.runs):
+                run_no += 1
+                lines = []
+
+                def log(msg, _lines=lines):
+                    print(msg)
+                    _lines.append(str(msg))
+
+                t0 = time.time()
+                note = ""
+                try:
+                    out = fn(task, log=log)
+                    answer, meter = out[0], out[1]
+                    if name == "plan_exec":
+                        note = f"replans={out[2]}"
+                except Exception as e:            # a crash is a failed run, not a lost run
+                    answer, meter, note = "", None, f"crash: {type(e).__name__}: {e}"
+                    log(note)
+                success = judge(answer, expected)
+                log(f"[final] {answer.strip()[:300]}")
+                log(f"[judge] expected={expected!r} -> {'O' if success else 'X'} "
+                    f"({time.time() - t0:.1f}s)")
+
+                Path("logs", f"{name}-{run_no:02d}.txt").write_text(
+                    "\n".join(lines) + "\n", encoding="utf-8")
+                w.writerow([run_no, name, "O" if success else "X",
+                            meter.tokens if meter else "",
+                            meter.iters if meter else "",
+                            meter.interventions if meter else "", note])
+                f.flush()
+    print("\nresults.csv updated;", os.path.abspath("results.csv"))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/26510126/week-02/run_early.py
+++ b/submissions/26510126/week-02/run_early.py
@@ -1,0 +1,73 @@
+"""Week 02 extension — run the early-exit harness and record results_early.csv.
+
+Kept out of run_ab.py and results.csv on purpose: check_week02.py treats any
+harness value other than react|plan_exec as a malformed row, and the eighteen
+graded runs should stay exactly as they were produced. Same task, same
+success criterion, same judge as run_ab.py — only the harness differs.
+
+Usage: python run_early.py [--runs 3]
+"""
+import argparse
+import csv
+import time
+from pathlib import Path
+
+from harness_plan_execute_early import run_plan_execute_early
+from run_ab import HEADER, judge, read_task
+from tools_shared import MODEL, PROVIDER, TOOLSET
+
+RESULTS = "results_early.csv"
+LOGDIR = "logs_early"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=3)
+    args = ap.parse_args()
+
+    task, expected = read_task()
+    Path(LOGDIR).mkdir(exist_ok=True)
+    new_file = not Path(RESULTS).exists()
+    run_no = 0
+    if not new_file:
+        with open(RESULTS, encoding="utf-8") as f:
+            run_no = sum(1 for _ in f) - 1
+
+    with open(RESULTS, "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new_file:
+            w.writerow(HEADER)
+        for _ in range(args.runs):
+            run_no += 1
+            lines = []
+
+            def log(msg, _lines=lines):
+                print(msg)
+                _lines.append(str(msg))
+
+            t0 = time.time()
+            note = f"{PROVIDER}:{MODEL} tools={TOOLSET}"
+            try:
+                answer, meter, replans = run_plan_execute_early(task, log=log)
+                note += f" replans={replans}"
+            except Exception as e:
+                answer, meter = "", None
+                note += f" crash: {type(e).__name__}: {e}"
+                log(note)
+            success = judge(answer, expected)
+            log(f"[final] {answer.strip()[:300]}")
+            log(f"[judge] expected={expected!r} -> {'O' if success else 'X'} "
+                f"({time.time() - t0:.1f}s)")
+
+            Path(LOGDIR, f"plan_exec_early-{run_no:02d}.txt").write_text(
+                "\n".join(lines) + "\n", encoding="utf-8")
+            w.writerow([run_no, "plan_exec_early", "O" if success else "X",
+                        meter.tokens if meter else "",
+                        meter.iters if meter else "",
+                        meter.interventions if meter else "", note])
+            f.flush()
+    print(f"\n{RESULTS} updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/26510126/week-02/tools_shared.py
+++ b/submissions/26510126/week-02/tools_shared.py
@@ -37,22 +37,67 @@ def count_pattern(path: str, pattern: str) -> str:
         return str(sum(1 for line in f if rx.search(line)))
 
 
-TOOLS_IMPL = {"read_file": read_file, "count_pattern": count_pattern}
+def count_by_hour(path: str, pattern: str) -> str:
+    """Tally matching lines per clock hour, one 'HH:00 n' line per hour.
 
-# provider-neutral schemas; Chat converts them per provider
-TOOL_SPECS = [
-    {"name": "read_file",
-     "description": "Read a text file in the working directory (first 4000 characters).",
-     "parameters": {"type": "object",
-                    "properties": {"path": {"type": "string"}},
-                    "required": ["path"]}},
-    {"name": "count_pattern",
-     "description": "Count the lines of a text file that match a regular expression.",
-     "parameters": {"type": "object",
-                    "properties": {"path": {"type": "string"},
-                                   "pattern": {"type": "string"}},
-                    "required": ["path", "pattern"]}},
-]
+    The coarse counterpart of count_pattern: the same tally that costs one
+    count_pattern call per hour costs one call here. Only in the coarse tool
+    set (AGENT_TOOLSET=coarse).
+    """
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    rx = re.compile(pattern)
+    hours = {}
+    with open(full, encoding="utf-8") as f:
+        for line in f:
+            if not rx.search(line):
+                continue
+            m = re.search(r"\b(\d{2}):\d{2}(?::\d{2})?\b", line)
+            if m:
+                hours[m.group(1)] = hours.get(m.group(1), 0) + 1
+    if not hours:
+        return "no matching lines with a recognisable HH:MM timestamp"
+    return "\n".join(f"{h}:00 {n}" for h, n in sorted(hours.items()))
+
+
+_READ_FILE_SPEC = {
+    "name": "read_file",
+    "description": "Read a text file in the working directory (first 4000 characters).",
+    "parameters": {"type": "object",
+                   "properties": {"path": {"type": "string"}},
+                   "required": ["path"]}}
+_COUNT_PATTERN_SPEC = {
+    "name": "count_pattern",
+    "description": "Count the lines of a text file that match a regular expression.",
+    "parameters": {"type": "object",
+                   "properties": {"path": {"type": "string"},
+                                  "pattern": {"type": "string"}},
+                   "required": ["path", "pattern"]}}
+_COUNT_BY_HOUR_SPEC = {
+    "name": "count_by_hour",
+    "description": ("Count the lines of a text file that match a regular expression, "
+                    "grouped by the clock hour of each line's HH:MM timestamp. "
+                    "Returns one 'HH:00 count' line per hour that has a match."),
+    "parameters": {"type": "object",
+                   "properties": {"path": {"type": "string"},
+                                  "pattern": {"type": "string"}},
+                   "required": ["path", "pattern"]}}
+
+# Tool granularity is element 2 of the five. It is a constant within any one
+# A/B — both harnesses import whatever this module exposes — but it can be
+# switched between experiments. "fine" is the starter set and the default, so
+# the runs recorded against it stay reproducible from this file unchanged.
+TOOLSET = os.environ.get("AGENT_TOOLSET", "fine")
+
+if TOOLSET == "coarse":
+    TOOLS_IMPL = {"read_file": read_file, "count_by_hour": count_by_hour}
+    TOOL_SPECS = [_READ_FILE_SPEC, _COUNT_BY_HOUR_SPEC]
+elif TOOLSET == "fine":
+    TOOLS_IMPL = {"read_file": read_file, "count_pattern": count_pattern}
+    TOOL_SPECS = [_READ_FILE_SPEC, _COUNT_PATTERN_SPEC]
+else:
+    raise SystemExit(f"AGENT_TOOLSET must be 'fine' or 'coarse', got {TOOLSET!r}")
 
 # ---------------------------------------------------------------- meter
 

--- a/submissions/26510126/week-02/tools_shared.py
+++ b/submissions/26510126/week-02/tools_shared.py
@@ -1,0 +1,192 @@
+"""Week 02 starter — tools, model call, and meter shared by both harnesses.
+
+Both harnesses import from here. Same tools and same model for both is what
+makes the A/B a harness comparison and not a tool comparison.
+
+Provider is picked from the environment:
+  ANTHROPIC_API_KEY set          -> Anthropic SDK (pip install anthropic)
+  otherwise                      -> OpenAI-compatible (pip install openai)
+                                    OPENAI_API_KEY, optional OPENAI_BASE_URL
+                                    (https://openrouter.ai/api/v1 for OpenRouter)
+  AGENT_MODEL                    optional model override for either provider
+"""
+import json
+import os
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------- tools
+
+
+def read_file(path: str) -> str:
+    """Return the contents of a text file in the working directory."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    with open(full, encoding="utf-8") as f:
+        return f.read()[:4000]          # context guard, same as week 01
+
+
+def count_pattern(path: str, pattern: str) -> str:
+    """Count lines in a text file that match a regular expression."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    rx = re.compile(pattern)
+    with open(full, encoding="utf-8") as f:
+        return str(sum(1 for line in f if rx.search(line)))
+
+
+TOOLS_IMPL = {"read_file": read_file, "count_pattern": count_pattern}
+
+# provider-neutral schemas; Chat converts them per provider
+TOOL_SPECS = [
+    {"name": "read_file",
+     "description": "Read a text file in the working directory (first 4000 characters).",
+     "parameters": {"type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]}},
+    {"name": "count_pattern",
+     "description": "Count the lines of a text file that match a regular expression.",
+     "parameters": {"type": "object",
+                    "properties": {"path": {"type": "string"},
+                                   "pattern": {"type": "string"}},
+                    "required": ["path", "pattern"]}},
+]
+
+# ---------------------------------------------------------------- meter
+
+
+class Meter:
+    """The four metrics of the lab, counted in one place."""
+
+    def __init__(self):
+        self.tokens = 0
+        self.iters = 0            # one iteration = one model call
+        self.interventions = 0    # times a human approved or denied a call
+
+    def add(self, input_tokens: int, output_tokens: int):
+        self.tokens += int(input_tokens or 0) + int(output_tokens or 0)
+        self.iters += 1
+
+
+# ---------------------------------------------------------------- model
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    args: dict
+
+
+@dataclass
+class Reply:
+    text: str
+    tool_calls: list = field(default_factory=list)
+
+
+PROVIDER = "anthropic" if os.environ.get("ANTHROPIC_API_KEY") else "openai"
+MODEL = os.environ.get(
+    "AGENT_MODEL",
+    "claude-sonnet-4-5" if PROVIDER == "anthropic" else "gpt-4o-mini")
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        if PROVIDER == "anthropic":
+            import anthropic
+            _client = anthropic.Anthropic()
+        else:
+            from openai import OpenAI
+            _client = OpenAI()
+    return _client
+
+
+class Chat:
+    """One conversation with the model. Owns the provider-specific message
+    format so the harnesses only see Reply and ToolCall."""
+
+    def __init__(self, system: str, meter: Meter, tools: bool = True):
+        self.system = system
+        self.meter = meter
+        self.tools = tools
+        self.messages = []
+        if PROVIDER == "openai":
+            self.messages.append({"role": "system", "content": system})
+
+    # ---- building the next turn
+    def add_user(self, text: str):
+        self.messages.append({"role": "user", "content": text})
+
+    def add_tool_result(self, call: ToolCall, output: str):
+        if PROVIDER == "anthropic":
+            block = {"type": "tool_result", "tool_use_id": call.id, "content": output}
+            last = self.messages[-1]
+            if last["role"] == "user" and isinstance(last["content"], list):
+                last["content"].append(block)
+            else:
+                self.messages.append({"role": "user", "content": [block]})
+        else:
+            self.messages.append({"role": "tool", "tool_call_id": call.id,
+                                  "content": output})
+
+    # ---- one model call
+    def send(self) -> Reply:
+        if PROVIDER == "anthropic":
+            return self._send_anthropic()
+        return self._send_openai()
+
+    def _send_anthropic(self) -> Reply:
+        kwargs = dict(model=MODEL, max_tokens=1024, system=self.system,
+                      messages=self.messages)
+        if self.tools:
+            kwargs["tools"] = [{"name": t["name"], "description": t["description"],
+                                "input_schema": t["parameters"]} for t in TOOL_SPECS]
+        resp = _get_client().messages.create(**kwargs)
+        self.meter.add(resp.usage.input_tokens, resp.usage.output_tokens)
+        self.messages.append({"role": "assistant", "content": resp.content})
+        text = "".join(b.text for b in resp.content if b.type == "text")
+        calls = [ToolCall(b.id, b.name, dict(b.input))
+                 for b in resp.content if b.type == "tool_use"]
+        return Reply(text, calls)
+
+    def _send_openai(self) -> Reply:
+        kwargs = dict(model=MODEL, messages=self.messages)
+        if self.tools:
+            kwargs["tools"] = [{"type": "function",
+                                "function": {"name": t["name"],
+                                             "description": t["description"],
+                                             "parameters": t["parameters"]}}
+                               for t in TOOL_SPECS]
+        resp = _get_client().chat.completions.create(**kwargs)
+        usage = resp.usage
+        self.meter.add(getattr(usage, "prompt_tokens", 0),
+                       getattr(usage, "completion_tokens", 0))
+        msg = resp.choices[0].message
+        self.messages.append(msg)
+        calls = []
+        for c in msg.tool_calls or []:
+            try:
+                args = json.loads(c.function.arguments or "{}")
+            except json.JSONDecodeError:
+                args = {"_raw": c.function.arguments}
+            calls.append(ToolCall(c.id, c.function.name, args))
+        return Reply(msg.content or "", calls)
+
+    # ---- run the tools a reply asked for, feed results back
+    def run_tools(self, reply: Reply, log=print) -> None:
+        for call in reply.tool_calls:
+            fn = TOOLS_IMPL.get(call.name)
+            if fn is None:
+                out = f"error: unknown tool {call.name}"
+            else:
+                try:
+                    out = str(fn(**call.args))
+                except Exception as e:           # error recovery: the error is an Observation
+                    out = f"error: {e}"
+            log(f"  [tool] {call.name}({call.args}) -> {out[:200].replace(chr(10), ' | ')}")
+            self.add_tool_result(call, out)


### PR DESCRIPTION
## What I built

Harness A/B on one task fixed in `TASK.md` — which hour in `app.log` has the most ERROR lines, expected `14:00`. ReAct and Plan-then-Execute run through the same `Chat` wrapper and the same tools in `tools_shared.py`, so only the harness varies. 18 graded runs in `results.csv` across three sets: Set A on `nvidia/nemotron-3.5-lightning:free` via OpenRouter, Set B on `claude-sonnet-5`, Set C on `claude-sonnet-5` with a coarse tool set.

The finding is that the termination condition moved the other metrics. ReAct ends when the model stops asking for tools; Plan-then-Execute ends when the plan list runs out. In Set B both answered 3/3, but plan_exec spent 5.9× the median tokens and 3.7× the iterations — `plan_exec-10`, `-11` and `-12` each print `Answer: 14:00` at step 1 and then walk the remaining steps anyway. Set C isolates tool granularity: swapping `count_pattern` for `count_by_hour` cut ReAct's median tokens 71% (5,895 → 1,704) and plan_exec's 8% (34,920 → 31,956), because plan_exec's call count is set by the plan's length, which a better tool does not shorten.

## What I tried and discarded

- **Success criterion.** The first version substring-matched the whole response. That scores a run O whenever it names `14:00` anywhere while concluding otherwise, and the two harnesses do not end the same way, so the error would not have fallen equally on them. Changed to the last `Answer:` line and written into `TASK.md` before the first run (`7d64d41`).
- **Set A is not usable for success rates.** Runs 5 and 6 are X rows with empty metrics — they hit OpenRouter's free-tier daily cap (`X-RateLimit-Remaining: 0`), not the task. They stay in `results.csv`, and Set B exists for the comparison. `run_ab.py` discards the `Meter` on an exception, so Set A's plan_exec token figure is an undercount of what was actually spent.
- **A third harness, then a negative result from it.** Sets A–C vary termination condition *and* context management at once, so attributing the gap to termination alone was inference. `harness_plan_execute_early.py` differs from the given harness by one branch: return when a step's reply already carries an `Answer:` line. Two of three runs dropped to 4 model calls, close to ReAct's 3. The third showed the branch is not a bound — its planner wrote 28 steps, the pattern those steps used was `HH:00 ERROR` which matches nothing because the timestamps carry real minutes, and the one permitted replan returned **52** steps rather than a shorter list (`max_replan` counts replans, not their size, and the splice takes the new list whole). 103 calls, 876,769 tokens. Kept in the report appendix and out of `results.csv`, because `check_week02.py` counts any harness value other than `react|plan_exec` as a malformed row.
- **Instrumentation I would change.** `Meter.add` sums input and output into one counter, so the cost figures in the report are ranges rather than numbers. And `run_early.py` truncates each step's reply to 300 characters when logging, so the deciding `Answer:` line in early-exit run 2 is not visible in its log — `answer_line()` and the judge read the untruncated text, so the O is correct, but the log does not show the evidence for it.

## How to run

Python 3.12.14; `anthropic` 1.4.0 for Sets B and C and the appendix, `openai` 3.6.0 for Set A.

```bash
cd submissions/26510126/week-02

# Set B — claude-sonnet-5, fine tools
ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
    python run_ab.py --runs 3

# Set C — same model, coarse tools
ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
    AGENT_TOOLSET=coarse python run_ab.py --runs 3

# Set A — OpenRouter free model
env -u ANTHROPIC_API_KEY \
    OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
    OPENAI_API_KEY=<openrouter key> \
    AGENT_MODEL=nvidia/nemotron-3.5-lightning:free \
    python run_ab.py --runs 3

# Appendix — the early-exit harness
ANTHROPIC_API_KEY=<console key> AGENT_MODEL=claude-sonnet-5 \
    python run_early.py --runs 3
```

## Checklist

- [x] `python scripts/check_week02.py submissions/26510126/week-02` passes locally
- [x] Run logs are committed under `logs/` (18 files) and `logs_early/` (3 files)
- [x] No API keys anywhere in the diff
- [x] History is not squashed (16 commits)
