### PR TITLE
[week-02] 25512092

### DIFF
--- a/submissions/25512092/week-02/TASK.md
+++ b/submissions/25512092/week-02/TASK.md
@@ -1,0 +1,15 @@
+# Task
+
+The same task for both harnesses. `run_ab.py` reads the `task:` and
+`expected:` lines below. Write the success criterion before you run
+anything, and do not change it after you see the results.
+
+task: In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form.
+
+## Success criterion
+
+A run succeeds when the final answer contains the hour with the most ERROR
+lines in `app.log`, written as HH:00. `app.log` is the reference input; the
+graded runs use it unchanged.
+
+expected: 14:00

--- a/submissions/25512092/week-02/app.log
+++ b/submissions/25512092/week-02/app.log
@@ -1,0 +1,60 @@
+2026-09-01 09:07:27 INFO  job finished in 320ms
+2026-09-01 09:11:56 ERROR NullReference in QuizService.score
+2026-09-01 09:13:14 INFO  health check ok
+2026-09-01 09:26:45 INFO  health check ok
+2026-09-01 09:30:17 INFO  health check ok
+2026-09-01 09:32:05 INFO  request served /api/quiz
+2026-09-01 10:07:50 INFO  session started
+2026-09-01 10:12:15 INFO  request served /api/quiz
+2026-09-01 10:18:22 ERROR db connection refused
+2026-09-01 10:23:48 WARN  retrying upstream call
+2026-09-01 10:53:22 WARN  slow query 1.8s on rooms
+2026-09-01 10:54:07 ERROR NullReference in QuizService.score
+2026-09-01 10:57:10 INFO  cache hit for room 4412
+2026-09-01 11:23:35 ERROR payment webhook signature mismatch
+2026-09-01 11:36:12 INFO  cache hit for room 4412
+2026-09-01 11:39:20 INFO  request served /api/quiz
+2026-09-01 11:40:27 WARN  slow query 1.8s on rooms
+2026-09-01 11:44:02 INFO  health check ok
+2026-09-01 11:56:13 INFO  request served /api/quiz
+2026-09-01 12:08:13 INFO  request served /api/quiz
+2026-09-01 12:28:08 ERROR upstream timeout after 5000ms
+2026-09-01 12:32:19 INFO  health check ok
+2026-09-01 12:49:54 ERROR db connection refused
+2026-09-01 12:50:06 WARN  token near expiry
+2026-09-01 12:53:48 ERROR upstream timeout after 5000ms
+2026-09-01 12:59:50 WARN  token near expiry
+2026-09-01 13:24:27 INFO  cache hit for room 4412
+2026-09-01 13:26:02 INFO  session started
+2026-09-01 13:28:15 INFO  request served /api/quiz
+2026-09-01 13:42:13 ERROR db connection refused
+2026-09-01 13:43:37 WARN  slow query 1.8s on rooms
+2026-09-01 13:59:54 ERROR upstream timeout after 5000ms
+2026-09-01 14:04:06 ERROR NullReference in QuizService.score
+2026-09-01 14:07:11 ERROR NullReference in QuizService.score
+2026-09-01 14:15:56 ERROR upstream timeout after 5000ms
+2026-09-01 14:19:13 INFO  health check ok
+2026-09-01 14:26:19 INFO  request served /api/quiz
+2026-09-01 14:30:20 ERROR db connection refused
+2026-09-01 14:43:37 INFO  job finished in 320ms
+2026-09-01 14:47:03 ERROR upstream timeout after 5000ms
+2026-09-01 14:54:53 ERROR upstream timeout after 5000ms
+2026-09-01 15:04:23 INFO  cache hit for room 4412
+2026-09-01 15:33:16 INFO  request served /api/quiz
+2026-09-01 15:34:38 ERROR payment webhook signature mismatch
+2026-09-01 15:39:25 INFO  cache hit for room 4412
+2026-09-01 15:41:14 ERROR NullReference in QuizService.score
+2026-09-01 15:45:36 INFO  cache hit for room 4412
+2026-09-01 15:48:41 WARN  token near expiry
+2026-09-01 16:11:35 INFO  request served /api/quiz
+2026-09-01 16:16:04 INFO  cache hit for room 4412
+2026-09-01 16:24:31 WARN  slow query 1.8s on rooms
+2026-09-01 16:44:46 INFO  session started
+2026-09-01 16:51:30 WARN  retrying upstream call
+2026-09-01 16:53:34 ERROR NullReference in QuizService.score
+2026-09-01 17:17:14 ERROR NullReference in QuizService.score
+2026-09-01 17:27:48 WARN  token near expiry
+2026-09-01 17:37:46 INFO  health check ok
+2026-09-01 17:48:38 WARN  token near expiry
+2026-09-01 17:55:29 INFO  job finished in 320ms
+2026-09-01 17:56:05 INFO  cache hit for room 4412

--- a/submissions/25512092/week-02/harness_plan_execute.py
+++ b/submissions/25512092/week-02/harness_plan_execute.py
@@ -1,0 +1,98 @@
+"""Week 02 starter — the Plan-then-Execute harness.
+
+One call produces the whole plan as a JSON list. Then each step is executed
+in order with tools. If a step reports OFF_PLAN, the plan is rebuilt once
+(max_replan=1): that number is the flexibility cap, and it is explicit.
+"""
+import json
+import re
+import sys
+
+from tools_shared import Chat, Meter, Reply
+
+SYSTEM_PLAN = (
+    "You are a planner. Reply with a JSON list of short strings, one per step, "
+    "and nothing else. No prose, no code fences."
+)
+SYSTEM_EXEC = (
+    "You execute one step of a plan at a time with the tools you are given. "
+    "If the step cannot be done as planned, reply with a line that starts with "
+    "'OFF_PLAN:' and explain why. When asked for the final answer, reply with a "
+    "line that starts with 'Answer:'."
+)
+
+
+def parse_plan(text: str):
+    """Return a list of step strings, or None if the model did not give JSON."""
+    text = re.sub(r"^```(?:json)?|```$", "", text.strip(), flags=re.M).strip()
+    try:
+        plan = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(plan, list) and all(isinstance(s, str) for s in plan):
+        return plan
+    return None
+
+
+def run_plan_execute(task: str, max_replan: int = 1,
+                     max_tool_rounds: int = 3, log=print):
+    meter = Meter()
+
+    # 1) PLAN: the whole plan in one call, no tools
+    planner = Chat(SYSTEM_PLAN, meter, tools=False)
+    planner.add_user(f"Task: {task}\nAvailable tools: read_file(path), "
+                     f"count_pattern(path, pattern).")
+    raw = planner.send().text
+    plan = parse_plan(raw)
+    if plan is None:                              # a parse failure is one failure mode
+        log(f"[plan] not valid JSON: {raw.strip()[:300]!r}")
+        return "plan parse failed", meter, 0
+    log(f"[plan] {plan}")
+
+    # 2) EXECUTE: each step in order
+    executor = Chat(SYSTEM_EXEC, meter)
+    executor.add_user(f"Task: {task}\nPlan: {json.dumps(plan)}")
+    replans = 0
+    i = 0
+    while i < len(plan):
+        executor.add_user(f"Execute step {i + 1}: {plan[i]}")
+        reply = executor.send()
+        rounds = 0
+        while reply.tool_calls:                   # tool calls inside one step
+            executor.run_tools(reply, log)
+            reply = executor.send()
+            rounds += 1
+            if rounds >= max_tool_rounds and reply.tool_calls:
+                executor.run_tools(reply, log)    # answer every call so the transcript stays valid
+                reply = Reply("OFF_PLAN: step exceeded the tool-call budget", [])
+                break
+        log(f"[step {i + 1}] {reply.text.strip()[:300]}")
+
+        if reply.text.strip().startswith("OFF_PLAN") and replans < max_replan:
+            replans += 1                          # flexibility cap
+            planner.add_user(f"Step {i + 1} ({plan[i]}) failed: {reply.text.strip()[:300]}\n"
+                             f"Reply with a JSON list of the remaining steps.")
+            raw = planner.send().text
+            new_steps = parse_plan(raw)
+            if new_steps is None:
+                log(f"[replan] not valid JSON: {raw.strip()[:300]!r}")
+                break
+            plan = plan[:i] + new_steps
+            log(f"[replan] {plan}")
+            continue
+        i += 1
+
+    executor.add_user("Give the final answer now, starting with 'Answer:'.")
+    final = executor.send()
+    if final.tool_calls:                          # the model tried to keep going
+        executor.run_tools(final, log)
+        final = executor.send()
+    return final.text, meter, replans
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m, replans = run_plan_execute(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions} replans={replans}")

--- a/submissions/25512092/week-02/harness_react.py
+++ b/submissions/25512092/week-02/harness_react.py
@@ -1,0 +1,60 @@
+"""Week 02 starter — the ReAct-style harness.
+
+Every step: the model writes a Thought, calls a tool (Action), sees the result
+(Observation), and decides again. The five axes from the lecture are marked.
+"""
+import sys
+
+from tools_shared import Chat, Meter
+
+SYSTEM = (
+    "You solve tasks with the tools you are given. Before every tool call, "
+    "write one line that starts with 'Thought:' saying what you know and what "
+    "you will do next. When the task is complete, reply with a line that starts "
+    "with 'Answer:' and make no tool call."
+)
+
+# [axis 5] calls that must be approved by a human before they run.
+# The starter tools are read-only, so this set is empty and interventions
+# stay at 0. Add a tool that writes or deletes, and put its name here.
+IRREVERSIBLE = set()
+
+
+def ask_human(call) -> bool:
+    answer = input(f"approve {call.name}({call.args})? [y/N] ").strip().lower()
+    return answer == "y"
+
+
+def run_react(task: str, max_steps: int = 8, log=print):
+    meter = Meter()
+    chat = Chat(SYSTEM, meter)                    # [axis 1] context: full history, every call
+    chat.add_user(task)
+
+    for step in range(max_steps):                 # [axis 3] termination: iteration cap
+        reply = chat.send()
+        if reply.text.strip():
+            log(f"[step {step + 1}] {reply.text.strip()}")
+
+        if not reply.tool_calls:                  # [axis 3] the model chose to finish
+            return reply.text, meter
+
+        approved = []
+        for call in reply.tool_calls:
+            if call.name in IRREVERSIBLE and not ask_human(call):
+                meter.interventions += 1          # [axis 5] intervention point
+                chat.add_tool_result(call, "denied: human did not approve")
+                continue
+            approved.append(call)
+        reply.tool_calls = approved
+        chat.run_tools(reply, log)                # [axis 2] granularity lives in tools_shared
+                                                  # [axis 4] errors come back as Observations
+
+    return "MAX_STEPS reached: incomplete", meter
+
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else \
+        "In app.log, which hour (HH:00) has the most ERROR lines? Answer with the hour in HH:00 form."
+    answer, m = run_react(task)
+    print(answer)
+    print(f"tokens={m.tokens} iters={m.iters} interventions={m.interventions}")

--- a/submissions/25512092/week-02/logs/plan_exec-04.txt
+++ b/submissions/25512092/week-02/logs/plan_exec-04.txt
@@ -1,0 +1,50 @@
+[plan] ['Read the log file to see its format and content', 'Count ERROR occurrences for each hour from 00:00 to 23:00', 'Identify which hour has the maximum ERROR count', 'Return the hour in HH:00 format']
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 1] Good! I can see the log file format. Each line starts with a timestamp in the format `YYYY-MM-DD HH:MM:SS`, followed by the log level (INFO, ERROR, WARN), and then the message. Now I need to count ERROR lines for each hour from 00:00 to 23:00 to find which hour has the most ERROR entries.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 00:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 01:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 02:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 03:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 04:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 05:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 06:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 07:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 08:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 09:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 10:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 11:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log'}) -> error: count_pattern() missing 1 required positional argument: 'pattern'
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 15:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 16:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 17:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 18:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 19:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 20:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 21:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 22:.*ERROR'}) -> 0
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 23:.*ERROR'}) -> 0
+[step 2] Perfect! I've counted ERROR occurrences for all hours. Here's the summary:
+
+- 00:00 - 0 errors
+- 01:00 - 0 errors
+- 02:00 - 0 errors
+- 03:00 - 0 errors
+- 04:00 - 0 errors
+- 05:00 - 0 errors
+- 06:00 - 0 errors
+- 07:00 - 0 errors
+- 08:00 - 0 errors
+- 09:00 - 1 error
+- 10:00 - 2 errors
+- 11:00 - 1 erro
+[step 3] Based on the counts from step 2, I can identify which hour has the maximum ERROR count:
+
+- Hour 14:00 has 6 ERROR lines, which is the highest count among all hours.
+
+The maximum ERROR count is 6, occurring at hour 14:00.
+[step 4] Answer: 14:00
+[final] Answer: 14:00
+[judge] expected='14:00' -> O (37.3s)

--- a/submissions/25512092/week-02/logs/plan_exec-05.txt
+++ b/submissions/25512092/week-02/logs/plan_exec-05.txt
@@ -1,0 +1,3 @@
+[plan] not valid JSON: 'I\'ll help you find the hour with the most ERROR lines in app.log.\n\n```json\n[\n  "Read the app.log file to examine its structure and content",\n  "Count ERROR patterns to understand the total number of errors",\n  "Extract hours from ERROR lines to identify the pattern",\n  "Count ERROR occurrences for e'
+[final] plan parse failed
+[judge] expected='14:00' -> X (3.4s)

--- a/submissions/25512092/week-02/logs/plan_exec-06.txt
+++ b/submissions/25512092/week-02/logs/plan_exec-06.txt
@@ -1,0 +1,3 @@
+[plan] not valid JSON: 'I\'ll help you find which hour has the most ERROR lines in app.log.\n\n```json\n[\n  "Read the app.log file to examine its content and format",\n  "Count ERROR patterns in the file to understand the data",\n  "Extract hour information from ERROR lines to identify the pattern",\n  "Count ERROR occurrences fo'
+[final] plan parse failed
+[judge] expected='14:00' -> X (3.7s)

--- a/submissions/25512092/week-02/logs/react-01.txt
+++ b/submissions/25512092/week-02/logs/react-01.txt
@@ -1,0 +1,37 @@
+[step 1] I'll help you find which hour has the most ERROR lines in app.log. Let me start by reading the file to understand its format.
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Now I can see the log format. Each line starts with a timestamp in the format "YYYY-MM-DD HH:MM:SS". I need to count ERROR lines for each hour. Let me count the ERROR lines for each hour I can see in the sample.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 09:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 10:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 11:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 15:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 16:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 17:.*ERROR'}) -> 1
+[step 3] Perfect! Based on the counts:
+- 09:00 - 1 ERROR
+- 10:00 - 2 ERRORs
+- 11:00 - 1 ERROR
+- 12:00 - 3 ERRORs
+- 13:00 - 2 ERRORs
+- 14:00 - 6 ERRORs (highest)
+- 15:00 - 2 ERRORs
+- 16:00 - 1 ERROR
+- 17:00 - 1 ERROR
+
+Answer: 14:00
+[final] Perfect! Based on the counts:
+- 09:00 - 1 ERROR
+- 10:00 - 2 ERRORs
+- 11:00 - 1 ERROR
+- 12:00 - 3 ERRORs
+- 13:00 - 2 ERRORs
+- 14:00 - 6 ERRORs (highest)
+- 15:00 - 2 ERRORs
+- 16:00 - 1 ERROR
+- 17:00 - 1 ERROR
+
+Answer: 14:00
+[judge] expected='14:00' -> O (17.5s)

--- a/submissions/25512092/week-02/logs/react-02.txt
+++ b/submissions/25512092/week-02/logs/react-02.txt
@@ -1,0 +1,39 @@
+[step 1] I'll help you find which hour has the most ERROR lines in app.log. Let me start by reading the file to understand its format.
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Now I can see the log format. Each line starts with a timestamp in format "YYYY-MM-DD HH:MM:SS". I need to count ERROR lines for each hour. Let me count ERROR lines for each hour systematically.
+
+Thought: I can see the log format with timestamps. I need to count ERROR lines for each hour. I'll use the count_pattern function to count ERRORs for each hour I see in the logs (09:00 through 17:00).
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 09:.* ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 10:.* ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 11:.* ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.* ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 13:.* ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.* ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 15:.* ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 16:.* ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 17:.* ERROR'}) -> 1
+[step 3] Perfect! Now I have the ERROR count for each hour:
+- 09:00 - 1 ERROR
+- 10:00 - 2 ERRORs
+- 11:00 - 1 ERROR
+- 12:00 - 3 ERRORs
+- 13:00 - 2 ERRORs
+- 14:00 - 6 ERRORs (highest!)
+- 15:00 - 2 ERRORs
+- 16:00 - 1 ERROR
+- 17:00 - 1 ERROR
+
+Answer: 14:00
+[final] Perfect! Now I have the ERROR count for each hour:
+- 09:00 - 1 ERROR
+- 10:00 - 2 ERRORs
+- 11:00 - 1 ERROR
+- 12:00 - 3 ERRORs
+- 13:00 - 2 ERRORs
+- 14:00 - 6 ERRORs (highest!)
+- 15:00 - 2 ERRORs
+- 16:00 - 1 ERROR
+- 17:00 - 1 ERROR
+
+Answer: 14:00
+[judge] expected='14:00' -> O (15.3s)

--- a/submissions/25512092/week-02/logs/react-03.txt
+++ b/submissions/25512092/week-02/logs/react-03.txt
@@ -1,0 +1,39 @@
+[step 1] I'll help you find which hour has the most ERROR lines in app.log. Let me start by reading the file to understand its format.
+  [tool] read_file({'path': 'app.log'}) -> 2026-09-01 09:07:27 INFO  job finished in 320ms | 2026-09-01 09:11:56 ERROR NullReference in QuizService.score | 2026-09-01 09:13:14 INFO  health check ok | 2026-09-01 09:26:45 INFO  health check ok | 2026-09
+[step 2] Good! I can see the log format. Now I need to count ERROR lines for each hour. Let me count errors for each hour I can see in the sample (09:00 through 17:00):
+
+Thought: I can see the log file has timestamps in "YYYY-MM-DD HH:MM:SS" format. I need to count ERROR lines for each hour. Let me count errors for each hour systematically.
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 09:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 10:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 11:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 12:.*ERROR'}) -> 3
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 13:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 14:.*ERROR'}) -> 6
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 15:.*ERROR'}) -> 2
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 16:.*ERROR'}) -> 1
+  [tool] count_pattern({'path': 'app.log', 'pattern': '^2026-09-01 17:.*ERROR'}) -> 1
+[step 3] Perfect! Let me summarize the ERROR counts by hour:
+- 09:00 - 1 ERROR
+- 10:00 - 2 ERRORs
+- 11:00 - 1 ERROR
+- 12:00 - 3 ERRORs
+- 13:00 - 2 ERRORs
+- 14:00 - 6 ERRORs (highest!)
+- 15:00 - 2 ERRORs
+- 16:00 - 1 ERROR
+- 17:00 - 1 ERROR
+
+Answer: 14:00
+[final] Perfect! Let me summarize the ERROR counts by hour:
+- 09:00 - 1 ERROR
+- 10:00 - 2 ERRORs
+- 11:00 - 1 ERROR
+- 12:00 - 3 ERRORs
+- 13:00 - 2 ERRORs
+- 14:00 - 6 ERRORs (highest!)
+- 15:00 - 2 ERRORs
+- 16:00 - 1 ERROR
+- 17:00 - 1 ERROR
+
+Answer: 14:00
+[judge] expected='14:00' -> O (15.0s)

--- a/submissions/25512092/week-02/report.md
+++ b/submissions/25512092/week-02/report.md
@@ -1,0 +1,77 @@
+# Week 02 — Harness A/B: ReAct vs Plan-then-Execute
+
+## 1. Variant definition
+
+모델(claude-sonnet-4-5), 태스크(app.log에서 ERROR가 가장 많은 시간대),
+도구 집합(read_file, count_pattern)을 고정하고 하네스만 바꿨다. 두
+하네스는 `tools_shared.py`의 같은 `TOOLS_IMPL`과 같은 `Chat`을 쓴다.
+
+다섯 축 중 두 하네스가 다르게 설정한 것은 셋이다.
+
+| 축            | ReAct                                                                  | Plan-then-Execute                                                                          |
+| ------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 컨텍스트 관리 | 전체 대화 이력을 유지하며 매 스텝의 Observation이 다음 판단에 반영된다 | 계획 단계는 `tools=False`로 도구 접근이 없다. 입력을 관찰하지 못한 채 전체 단계가 결정된다 |
+| 종료 조건     | 모델이 도구 호출 없이 응답하거나 `max_steps=8` 도달                    | 계획의 단계 소진 후 최종 답 요청                                                           |
+| 오류 복구     | 도구 오류가 Observation으로 되돌아와 다음 스텝에서 재시도 가능         | 실행 단계는 OFF_PLAN 시 replan 1회 허용. 계획 파싱 실패에는 복구 경로가 없다               |
+
+도구 세분성은 두 하네스가 동일하다. 사람 개입 지점은 `IRREVERSIBLE`이
+빈 집합이라 양쪽 모두 0으로 고정된다. 스타터 도구가 읽기 전용이기
+때문이며, 하네스 차이에서 온 값이 아니다.
+
+## 2. Measurements
+
+| run | harness   | success | tokens | iters | interventions | note      |
+| --- | --------- | ------- | ------ | ----- | ------------- | --------- |
+| 1   | react     | O       | 6809   | 3     | 0             |           |
+| 2   | react     | O       | 6914   | 3     | 0             |           |
+| 3   | react     | O       | 6886   | 3     | 0             |           |
+| 4   | plan_exec | O       | 31403  | 9     | 0             | replans=0 |
+| 5   | plan_exec | X       | 200    | 1     | 0             | replans=0 |
+| 6   | plan_exec | X       | 201    | 1     | 0             | replans=0 |
+
+ReAct 3/3 성공, 평균 6,870 토큰, 3 iterations. Plan-then-Execute 1/3
+성공. 성공한 실행은 31,403 토큰으로 ReAct의 4.6배, 9 iterations로 3배였다.
+실패한 두 실행은 200토큰에서 종료됐다. 계획 호출 한 번만 소비한 값이다.
+
+## 3. Interpretation
+
+축마다 움직인 지표가 달랐다.
+
+오류 복구 축이 성공률을 갈랐다. Plan-then-Execute의 실패 2회는 모두
+계획 파싱 단계에서 발생했다. `SYSTEM_PLAN`은 "No prose, no code fences"를
+명시했으나 모델은 `I'll help you find the hour with the most ERROR lines
+in app.log.` 라는 문장을 앞에 붙이고 JSON을 코드펜스로 감쌌다
+(`logs/plan_exec-05.txt`, `plan_exec-06.txt`). `parse_plan`은 펜스는
+제거하지만 앞선 산문은 처리하지 못해 `json.loads`가 실패했고, 하네스는
+`return "plan parse failed"`로 즉시 종료했다. 계획 내용 자체는 타당했으므로
+추론 실패가 아니라 형식 불일치다. replan은 실행 단계의 OFF_PLAN에만
+적용되므로 이 지점에는 복구 경로가 없다. 반면 ReAct는 오류가
+Observation으로 되돌아온다. 성공한 Plan 실행에서도 `count_pattern`을
+pattern 인자 없이 호출해 에러가 났지만 곧바로 재호출로 복구했다
+(`logs/plan_exec-04.txt`). 차이는 오류가 나느냐가 아니라, 오류가 난
+지점에 다음 스텝이 있느냐다.
+
+컨텍스트 관리 축이 토큰과 반복 횟수를 갈랐다. 성공한 Plan 실행은
+00:00부터 23:00까지 24개 시간대를 모두 셌다. 계획 단계의 `Chat`은
+`tools=False`로 생성되어 `read_file`을 호출할 수 없으므로, 로그가 어느
+시간대를 담고 있는지 모르는 상태에서 전 범위를 훑는 계획을 세울 수밖에
+없었다. ReAct는 첫 스텝에서 `read_file`로 로그를 읽어 09:00~17:00
+범위임을 확인한 뒤 9개 시간대만 셌다(`logs/react-01.txt`). 같은 정답에
+도달했지만 15개의 불필요한 도구 호출이 토큰 4.6배, 반복 3배의 차이를
+만들었다. 관찰을 계획에 되먹일 수 없다는 구조가 그대로 비용이 됐다.
+
+이 태스크에서는 ReAct가 세 지표 모두 앞섰다. 다만 이는 태스크 성격에서
+온 결과이기도 하다. 탐색 범위를 실행 중에 좁힐 수 있는 문제였기 때문에
+관찰 반영의 이점이 컸다. 단계가 고정되어 있고 중간 관찰이 계획을 바꿀
+여지가 없는 태스크라면 Plan-then-Execute의 예측 가능성이 유리할 수 있다.
+또한 계획 파싱 실패는 하네스 설계보다 모델의 형식 준수 능력에 달린
+문제이므로, 구조화 출력을 강제하는 API를 쓰면 성공률 차이는 줄어들 것이다.
+
+## 4. How to run
+
+- Python 3.10+, `pip install anthropic`
+- Provider: Anthropic (`ANTHROPIC_API_KEY`가 설정되면 자동 선택)
+- Model: `claude-sonnet-4-5` (`tools_shared.py`의 기본값, `AGENT_MODEL`로 재정의 가능)
+- 도구: `read_file(path)`, `count_pattern(path, pattern)` — 두 하네스가
+  `tools_shared.py`에서 동일하게 import
+- 파라미터: ReAct `max_steps=8` / Plan-then-Execute `max_replan=1`, `max_tool_rounds=3`

--- a/submissions/25512092/week-02/results.csv
+++ b/submissions/25512092/week-02/results.csv
@@ -1,0 +1,7 @@
+run,harness,success,tokens,iters,interventions,note
+1,react,O,6809,3,0,
+2,react,O,6914,3,0,
+3,react,O,6886,3,0,
+4,plan_exec,O,31403,9,0,replans=0
+5,plan_exec,X,200,1,0,replans=0
+6,plan_exec,X,201,1,0,replans=0

--- a/submissions/25512092/week-02/run_ab.py
+++ b/submissions/25512092/week-02/run_ab.py
@@ -1,0 +1,90 @@
+"""Week 02 starter — run the A/B experiment and record results.csv.
+
+Usage: python run_ab.py [--runs 3]
+
+Reads the task and the success criterion from TASK.md, runs each harness
+--runs times, judges every run, appends one line per run to results.csv,
+and saves each run's console output under logs/. Failed runs are kept:
+they are data.
+"""
+import argparse
+import csv
+import os
+import re
+import time
+from pathlib import Path
+
+from harness_plan_execute import run_plan_execute
+from harness_react import run_react
+
+HEADER = ["run", "harness", "success", "tokens", "iters", "interventions", "note"]
+
+
+def read_task(path="TASK.md"):
+    text = Path(path).read_text(encoding="utf-8")
+    task = re.search(r"^task:\s*(.+)$", text, flags=re.M)
+    expected = re.search(r"^expected:\s*(.+)$", text, flags=re.M)
+    if not task or not expected:
+        raise SystemExit("TASK.md needs a 'task:' line and an 'expected:' line")
+    return task.group(1).strip(), expected.group(1).strip()
+
+
+def judge(answer: str, expected: str) -> bool:
+    """Success = the expected string appears in the final answer. Fix the
+    criterion in TASK.md before running; do not loosen it afterwards."""
+    return expected.lower() in (answer or "").lower()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=3)
+    args = ap.parse_args()
+
+    task, expected = read_task()
+    Path("logs").mkdir(exist_ok=True)
+    new_file = not Path("results.csv").exists()
+    run_no = 0
+    if not new_file:
+        with open("results.csv", encoding="utf-8") as f:
+            run_no = sum(1 for _ in f) - 1
+
+    with open("results.csv", "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new_file:
+            w.writerow(HEADER)
+        for name, fn in (("react", run_react), ("plan_exec", run_plan_execute)):
+            for _ in range(args.runs):
+                run_no += 1
+                lines = []
+
+                def log(msg, _lines=lines):
+                    print(msg)
+                    _lines.append(str(msg))
+
+                t0 = time.time()
+                note = ""
+                try:
+                    out = fn(task, log=log)
+                    answer, meter = out[0], out[1]
+                    if name == "plan_exec":
+                        note = f"replans={out[2]}"
+                except Exception as e:            # a crash is a failed run, not a lost run
+                    answer, meter, note = "", None, f"crash: {type(e).__name__}: {e}"
+                    log(note)
+                success = judge(answer, expected)
+                log(f"[final] {answer.strip()[:300]}")
+                log(f"[judge] expected={expected!r} -> {'O' if success else 'X'} "
+                    f"({time.time() - t0:.1f}s)")
+
+                Path("logs", f"{name}-{run_no:02d}.txt").write_text(
+                    "\n".join(lines) + "\n", encoding="utf-8")
+                w.writerow([run_no, name, "O" if success else "X",
+                            meter.tokens if meter else "",
+                            meter.iters if meter else "",
+                            meter.interventions if meter else "", note])
+                f.flush()
+    print("\nresults.csv updated;", os.path.abspath("results.csv"))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/25512092/week-02/tools_shared.py
+++ b/submissions/25512092/week-02/tools_shared.py
@@ -1,0 +1,192 @@
+"""Week 02 starter — tools, model call, and meter shared by both harnesses.
+
+Both harnesses import from here. Same tools and same model for both is what
+makes the A/B a harness comparison and not a tool comparison.
+
+Provider is picked from the environment:
+  ANTHROPIC_API_KEY set          -> Anthropic SDK (pip install anthropic)
+  otherwise                      -> OpenAI-compatible (pip install openai)
+                                    OPENAI_API_KEY, optional OPENAI_BASE_URL
+                                    (https://openrouter.ai/api/v1 for OpenRouter)
+  AGENT_MODEL                    optional model override for either provider
+"""
+import json
+import os
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------- tools
+
+
+def read_file(path: str) -> str:
+    """Return the contents of a text file in the working directory."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    with open(full, encoding="utf-8") as f:
+        return f.read()[:4000]          # context guard, same as week 01
+
+
+def count_pattern(path: str, pattern: str) -> str:
+    """Count lines in a text file that match a regular expression."""
+    full = os.path.abspath(path)
+    if not full.startswith(os.getcwd()):
+        return "denied: path outside the working directory"
+    rx = re.compile(pattern)
+    with open(full, encoding="utf-8") as f:
+        return str(sum(1 for line in f if rx.search(line)))
+
+
+TOOLS_IMPL = {"read_file": read_file, "count_pattern": count_pattern}
+
+# provider-neutral schemas; Chat converts them per provider
+TOOL_SPECS = [
+    {"name": "read_file",
+     "description": "Read a text file in the working directory (first 4000 characters).",
+     "parameters": {"type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]}},
+    {"name": "count_pattern",
+     "description": "Count the lines of a text file that match a regular expression.",
+     "parameters": {"type": "object",
+                    "properties": {"path": {"type": "string"},
+                                   "pattern": {"type": "string"}},
+                    "required": ["path", "pattern"]}},
+]
+
+# ---------------------------------------------------------------- meter
+
+
+class Meter:
+    """The four metrics of the lab, counted in one place."""
+
+    def __init__(self):
+        self.tokens = 0
+        self.iters = 0            # one iteration = one model call
+        self.interventions = 0    # times a human approved or denied a call
+
+    def add(self, input_tokens: int, output_tokens: int):
+        self.tokens += int(input_tokens or 0) + int(output_tokens or 0)
+        self.iters += 1
+
+
+# ---------------------------------------------------------------- model
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    args: dict
+
+
+@dataclass
+class Reply:
+    text: str
+    tool_calls: list = field(default_factory=list)
+
+
+PROVIDER = "anthropic" if os.environ.get("ANTHROPIC_API_KEY") else "openai"
+MODEL = os.environ.get(
+    "AGENT_MODEL",
+    "claude-sonnet-4-5" if PROVIDER == "anthropic" else "gpt-4o-mini")
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        if PROVIDER == "anthropic":
+            import anthropic
+            _client = anthropic.Anthropic()
+        else:
+            from openai import OpenAI
+            _client = OpenAI()
+    return _client
+
+
+class Chat:
+    """One conversation with the model. Owns the provider-specific message
+    format so the harnesses only see Reply and ToolCall."""
+
+    def __init__(self, system: str, meter: Meter, tools: bool = True):
+        self.system = system
+        self.meter = meter
+        self.tools = tools
+        self.messages = []
+        if PROVIDER == "openai":
+            self.messages.append({"role": "system", "content": system})
+
+    # ---- building the next turn
+    def add_user(self, text: str):
+        self.messages.append({"role": "user", "content": text})
+
+    def add_tool_result(self, call: ToolCall, output: str):
+        if PROVIDER == "anthropic":
+            block = {"type": "tool_result", "tool_use_id": call.id, "content": output}
+            last = self.messages[-1]
+            if last["role"] == "user" and isinstance(last["content"], list):
+                last["content"].append(block)
+            else:
+                self.messages.append({"role": "user", "content": [block]})
+        else:
+            self.messages.append({"role": "tool", "tool_call_id": call.id,
+                                  "content": output})
+
+    # ---- one model call
+    def send(self) -> Reply:
+        if PROVIDER == "anthropic":
+            return self._send_anthropic()
+        return self._send_openai()
+
+    def _send_anthropic(self) -> Reply:
+        kwargs = dict(model=MODEL, max_tokens=1024, system=self.system,
+                      messages=self.messages)
+        if self.tools:
+            kwargs["tools"] = [{"name": t["name"], "description": t["description"],
+                                "input_schema": t["parameters"]} for t in TOOL_SPECS]
+        resp = _get_client().messages.create(**kwargs)
+        self.meter.add(resp.usage.input_tokens, resp.usage.output_tokens)
+        self.messages.append({"role": "assistant", "content": resp.content})
+        text = "".join(b.text for b in resp.content if b.type == "text")
+        calls = [ToolCall(b.id, b.name, dict(b.input))
+                 for b in resp.content if b.type == "tool_use"]
+        return Reply(text, calls)
+
+    def _send_openai(self) -> Reply:
+        kwargs = dict(model=MODEL, messages=self.messages)
+        if self.tools:
+            kwargs["tools"] = [{"type": "function",
+                                "function": {"name": t["name"],
+                                             "description": t["description"],
+                                             "parameters": t["parameters"]}}
+                               for t in TOOL_SPECS]
+        resp = _get_client().chat.completions.create(**kwargs)
+        usage = resp.usage
+        self.meter.add(getattr(usage, "prompt_tokens", 0),
+                       getattr(usage, "completion_tokens", 0))
+        msg = resp.choices[0].message
+        self.messages.append(msg)
+        calls = []
+        for c in msg.tool_calls or []:
+            try:
+                args = json.loads(c.function.arguments or "{}")
+            except json.JSONDecodeError:
+                args = {"_raw": c.function.arguments}
+            calls.append(ToolCall(c.id, c.function.name, args))
+        return Reply(msg.content or "", calls)
+
+    # ---- run the tools a reply asked for, feed results back
+    def run_tools(self, reply: Reply, log=print) -> None:
+        for call in reply.tool_calls:
+            fn = TOOLS_IMPL.get(call.name)
+            if fn is None:
+                out = f"error: unknown tool {call.name}"
+            else:
+                try:
+                    out = str(fn(**call.args))
+                except Exception as e:           # error recovery: the error is an Observation
+                    out = f"error: {e}"
+            log(f"  [tool] {call.name}({call.args}) -> {out[:200].replace(chr(10), ' | ')}")
+            self.add_tool_result(call, out)


### PR DESCRIPTION
## What I built

app.log에서 ERROR가 가장 많은 시간대를 찾는 태스크를 ReAct형과
Plan-then-Execute형 두 하네스로 각각 3회씩 실행하고, 성공률·토큰·반복·
개입 횟수를 비교했다. 모델·태스크·도구는 고정하고 하네스만 변경했다.
상세는 `REPORT.md`.

## What I tried and discarded

Plan-then-Execute 3회 중 2회가 계획 파싱 단계에서 실패했다. `SYSTEM_PLAN`이
"No prose, no code fences"를 명시했음에도 모델이 설명 문장을 앞에 붙여
`json.loads`가 깨졌다. 실패 행(run 5, 6)은 `results.csv`에 그대로 두었다.
파서를 고쳐 실패를 우회하는 대신, 실패 자체를 결과로 기록했다.

저장소 fork 연결 문제로 기존 PR을 닫고 새 fork에서 다시 열었다.
커밋 히스토리는 그대로다.

## How to run

- Python 3.10+, `pip install anthropic`
- Model: `claude-sonnet-4-5` (`tools_shared.py` 기본값)
- 환경변수 `ANTHROPIC_API_KEY` 설정 후:
  `cd submissions/25512092/week-02 && python run_ab.py --runs 3`
- 성공 기준은 실행 전 커밋 `df8acba`의 `TASK.md`에 기록 (`expected: 14:00`)

## Checklist

- [x] `python scripts/check_week02.py submissions/25512092/week-02` passes locally
- [x] Run logs are committed under `logs/`
- [x] No API keys anywhere in the diff
- [x] History is not squashed